### PR TITLE
CI: consume prebuilt QtKeychain SDKs

### DIFF
--- a/.github/actions/setup-windows-desktop/action.yml
+++ b/.github/actions/setup-windows-desktop/action.yml
@@ -1,5 +1,5 @@
 name: Setup Windows desktop build
-description: Install Qt/MSVC/Conan and unpack the prebuilt QCA/Iris SDKs used by desktop Windows builds
+description: Install Qt/MSVC/Conan and unpack the prebuilt QCA/Iris/QtKeychain SDKs used by desktop Windows builds
 
 inputs:
   qt-version:
@@ -10,6 +10,15 @@ inputs:
     required: true
   iris-tag:
     description: psi-im/iris release tag
+    required: true
+  qtkeychain-tag:
+    description: AnyKeep QtKeychain dependency release tag
+    required: true
+  qtkeychain-version:
+    description: QtKeychain version used in the dependency asset name
+    required: true
+  qtkeychain-revision:
+    description: AnyKeep QtKeychain dependency bundle revision
     required: true
   aqt-source:
     description: aqtinstall source used for Qt 6.11 repository support
@@ -39,20 +48,27 @@ runs:
         python -m pip install --upgrade "conan>=2,<3"
         conan profile detect --force
 
-    - name: Download QCA/Iris SDKs
+    - name: Download QCA/Iris/QtKeychain SDKs
       shell: pwsh
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         QCA_TAG: ${{ inputs.qca-tag }}
         IRIS_TAG: ${{ inputs.iris-tag }}
+        QTKEYCHAIN_TAG: ${{ inputs.qtkeychain-tag }}
+        QTKEYCHAIN_VERSION: ${{ inputs.qtkeychain-version }}
+        QTKEYCHAIN_REVISION: ${{ inputs.qtkeychain-revision }}
       run: |
-        New-Item -ItemType Directory -Force qca-sdk, iris-sdk | Out-Null
+        New-Item -ItemType Directory -Force qca-sdk, iris-sdk, qtkeychain-sdk | Out-Null
 
         gh release download $env:QCA_TAG --repo psi-im/qca `
           -p qca3-qt6-windows-x64.zip -O qca.zip
 
         gh release download $env:IRIS_TAG --repo psi-im/iris `
           -p iris-qt6-windows-x64.zip -O iris.zip
+
+        $qtkeychainAsset = "qtkeychain-$env:QTKEYCHAIN_VERSION-$env:QTKEYCHAIN_REVISION-qt6.11-windows-x64.tar.gz"
+        gh release download $env:QTKEYCHAIN_TAG --repo $env:GITHUB_REPOSITORY `
+          -p $qtkeychainAsset -O qtkeychain.tar.gz
 
         Push-Location qca-sdk
         cmake -E tar xvf ../qca.zip
@@ -62,11 +78,21 @@ runs:
         cmake -E tar xvf ../iris.zip
         Pop-Location
 
+        Push-Location qtkeychain-sdk
+        cmake -E tar xvf ../qtkeychain.tar.gz
+        Pop-Location
+
         if (-not (Test-Path qca-sdk/lib/cmake/Qca3-qt6)) {
           throw "QCA CMake package missing"
         }
         if (-not (Test-Path iris-sdk/lib/cmake/Iris)) {
           throw "Iris CMake package missing"
+        }
+        if (-not (Test-Path qtkeychain-sdk/lib/cmake/Qt6Keychain/Qt6KeychainConfig.cmake)) {
+          throw "QtKeychain CMake package missing"
+        }
+        if (-not (Test-Path qtkeychain-sdk/lib/qt6keychain.lib)) {
+          throw "QtKeychain static library missing"
         }
 
         "$pwd\qca-sdk\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ env:
   QT_CURRENT_SERIES: "6.11.*"
   QCA_TAG: v3.0.1
   IRIS_TAG: v1.0.3
+  QTKEYCHAIN_TAG: deps-qtkeychain-0.14.3-r1-qt6.11
+  QTKEYCHAIN_VERSION: "0.14.3"
+  QTKEYCHAIN_REVISION: "r1"
   # aqtinstall 3.3.0 cannot read the new Windows Qt 6.11 repository layout.
   # PR #1000 contains the upstream fix; remove this override after aqt releases it.
   AQT_WINDOWS_QT611_SOURCE: "git+https://github.com/miurahr/aqtinstall.git@refs/pull/1000/head"
@@ -41,6 +44,9 @@ jobs:
           qt-version: ${{ env.QT_CURRENT_SERIES }}
           qca-tag: ${{ env.QCA_TAG }}
           iris-tag: ${{ env.IRIS_TAG }}
+          qtkeychain-tag: ${{ env.QTKEYCHAIN_TAG }}
+          qtkeychain-version: ${{ env.QTKEYCHAIN_VERSION }}
+          qtkeychain-revision: ${{ env.QTKEYCHAIN_REVISION }}
           aqt-source: ${{ env.AQT_WINDOWS_QT611_SOURCE }}
           github-token: ${{ github.token }}
 
@@ -51,8 +57,10 @@ jobs:
             -DANYKEEP_UPDATE_CHANNEL=nightly `
             -DANYKEEP_BUILD_BUNDLED_QCA=OFF `
             -DANYKEEP_BUILD_BUNDLED_IRIS=OFF `
+            -DANYKEEP_BUILD_BUNDLED_QTKEYCHAIN=OFF `
             -DANYKEEP_QCA_SDK_ROOT="$pwd/qca-sdk" `
             -DANYKEEP_IRIS_SDK_ROOT="$pwd/iris-sdk" `
+            -DANYKEEP_QTKEYCHAIN_SDK_ROOT="$pwd/qtkeychain-sdk" `
             -DBUILD_TESTING=ON
 
       - name: Build
@@ -201,11 +209,12 @@ jobs:
           brew list openssl@3 >/dev/null 2>&1 || brew install openssl@3
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
 
-      - name: Download QCA/Iris SDKs
+      - name: Download QCA/Iris/QtKeychain SDKs
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          mkdir -p qca-sdk iris-sdk
+          set -euo pipefail
+          mkdir -p qca-sdk iris-sdk qtkeychain-sdk
 
           gh release download "$IRIS_TAG" \
             --repo psi-im/iris \
@@ -217,8 +226,20 @@ jobs:
             -p "qca3-qt6-macos-x86_64.zip" \
             -O qca.zip
 
+          qtkeychain_asset="qtkeychain-${QTKEYCHAIN_VERSION}-${QTKEYCHAIN_REVISION}-qt6.11-macos-x86_64.tar.gz"
+          gh release download "$QTKEYCHAIN_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            -p "$qtkeychain_asset" \
+            -O qtkeychain.tar.gz
+
           (cd qca-sdk && cmake -E tar xvf ../qca.zip)
           (cd iris-sdk && cmake -E tar xvf ../iris.zip)
+          tar -xzf qtkeychain.tar.gz -C qtkeychain-sdk
+
+          test -d qca-sdk/lib/cmake/Qca3-qt6
+          test -d iris-sdk/lib/cmake/Iris
+          test -f qtkeychain-sdk/lib/cmake/Qt6Keychain/Qt6KeychainConfig.cmake
+          test -f qtkeychain-sdk/lib/libqt6keychain.a
 
       - name: Configure
         run: |
@@ -227,9 +248,10 @@ jobs:
             -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" \
             -DANYKEEP_BUILD_BUNDLED_QCA=OFF \
             -DANYKEEP_BUILD_BUNDLED_IRIS=OFF \
-            -DANYKEEP_BUILD_BUNDLED_QTKEYCHAIN=ON \
+            -DANYKEEP_BUILD_BUNDLED_QTKEYCHAIN=OFF \
             -DANYKEEP_QCA_SDK_ROOT="$PWD/qca-sdk" \
             -DANYKEEP_IRIS_SDK_ROOT="$PWD/iris-sdk" \
+            -DANYKEEP_QTKEYCHAIN_SDK_ROOT="$PWD/qtkeychain-sdk" \
             -DANYKEEP_BUILD_BUNDLED_QXMPP=OFF \
             -DANYKEEP_BUILD_BUNDLED_QCORO=OFF \
             -DBUILD_TESTING=OFF

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -23,6 +23,9 @@ env:
   QT_CURRENT_SERIES: "6.11.*"
   QCA_TAG: v3.0.1
   IRIS_TAG: v1.0.3
+  QTKEYCHAIN_TAG: deps-qtkeychain-0.14.3-r1-qt6.11
+  QTKEYCHAIN_VERSION: "0.14.3"
+  QTKEYCHAIN_REVISION: "r1"
   ANDROID_NDK_VERSION: r27c
   ANDROID_API: 28
   ANDROID_OPENSSL_REVISION: b71f1470962019bd89534a2919f5925f93bc5779
@@ -164,6 +167,9 @@ jobs:
           qt-version: ${{ env.QT_CURRENT_SERIES }}
           qca-tag: ${{ env.QCA_TAG }}
           iris-tag: ${{ env.IRIS_TAG }}
+          qtkeychain-tag: ${{ env.QTKEYCHAIN_TAG }}
+          qtkeychain-version: ${{ env.QTKEYCHAIN_VERSION }}
+          qtkeychain-revision: ${{ env.QTKEYCHAIN_REVISION }}
           aqt-source: ${{ env.AQT_WINDOWS_QT611_SOURCE }}
           github-token: ${{ github.token }}
 
@@ -188,11 +194,12 @@ jobs:
             -DANYKEEP_XMPP_BACKEND=IRIS `
             -DANYKEEP_QCA_SDK_ROOT="$pwd/qca-sdk" `
             -DANYKEEP_IRIS_SDK_ROOT="$pwd/iris-sdk" `
+            -DANYKEEP_QTKEYCHAIN_SDK_ROOT="$pwd/qtkeychain-sdk" `
             -DANYKEEP_BUILD_BUNDLED_QCA=OFF `
             -DANYKEEP_BUILD_BUNDLED_IRIS=OFF `
             -DANYKEEP_BUILD_BUNDLED_QXMPP=OFF `
             -DANYKEEP_BUILD_BUNDLED_QCORO=OFF `
-            -DANYKEEP_BUILD_BUNDLED_QTKEYCHAIN=ON `
+            -DANYKEEP_BUILD_BUNDLED_QTKEYCHAIN=OFF `
             -DANYKEEP_INSTALL_PREBUILT_SDK_RUNTIME=ON `
             "-DANYKEEP_MSIX_IDENTITY_NAME=${{ vars.ANYKEEP_MSIX_IDENTITY_NAME }}" `
             "-DANYKEEP_MSIX_PUBLISHER=${{ vars.ANYKEEP_MSIX_PUBLISHER }}" `
@@ -346,21 +353,27 @@ jobs:
           brew list openssl@3 >/dev/null 2>&1 || brew install openssl@3
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
 
-      - name: Download QCA/Iris SDKs
+      - name: Download QCA/Iris/QtKeychain SDKs
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          mkdir qca-sdk iris-sdk
+          mkdir qca-sdk iris-sdk qtkeychain-sdk
           gh release download "$QCA_TAG" --repo psi-im/qca \
             -p "qca3-qt6-macos-${{ matrix.arch }}.zip" -O qca.zip
           gh release download "$IRIS_TAG" --repo psi-im/iris \
             -p "iris-qt6-macos-${{ matrix.arch }}.zip" -O iris.zip
+          qtkeychain_asset="qtkeychain-${QTKEYCHAIN_VERSION}-${QTKEYCHAIN_REVISION}-qt6.11-macos-${{ matrix.arch }}.tar.gz"
+          gh release download "$QTKEYCHAIN_TAG" --repo "$GITHUB_REPOSITORY" \
+            -p "$qtkeychain_asset" -O qtkeychain.tar.gz
           (cd qca-sdk && cmake -E tar xvf ../qca.zip)
           (cd iris-sdk && cmake -E tar xvf ../iris.zip)
+          tar -xzf qtkeychain.tar.gz -C qtkeychain-sdk
           test -d qca-sdk/lib/cmake/Qca3-qt6
           test -d iris-sdk/lib/cmake/Iris
+          test -f qtkeychain-sdk/lib/cmake/Qt6Keychain/Qt6KeychainConfig.cmake
+          test -f qtkeychain-sdk/lib/libqt6keychain.a
 
       - name: Configure and build
         shell: bash
@@ -372,11 +385,12 @@ jobs:
             -DANYKEEP_XMPP_BACKEND=IRIS \
             -DANYKEEP_QCA_SDK_ROOT="$PWD/qca-sdk" \
             -DANYKEEP_IRIS_SDK_ROOT="$PWD/iris-sdk" \
+            -DANYKEEP_QTKEYCHAIN_SDK_ROOT="$PWD/qtkeychain-sdk" \
             -DANYKEEP_BUILD_BUNDLED_QCA=OFF \
             -DANYKEEP_BUILD_BUNDLED_IRIS=OFF \
             -DANYKEEP_BUILD_BUNDLED_QXMPP=OFF \
             -DANYKEEP_BUILD_BUNDLED_QCORO=OFF \
-            -DANYKEEP_BUILD_BUNDLED_QTKEYCHAIN=ON \
+            -DANYKEEP_BUILD_BUNDLED_QTKEYCHAIN=OFF \
             -DANYKEEP_INSTALL_PREBUILT_SDK_RUNTIME=ON \
             -DBUILD_TESTING=OFF
           cmake --build build/package --parallel 4
@@ -492,27 +506,34 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.QT_CURRENT_SERIES }}
+          host: all_os
           target: android
           arch: ${{ matrix.qt-arch }}
           modules: qtmultimedia qttasktree
           aqtsource: ${{ env.AQT_WINDOWS_QT611_SOURCE }}
           cache: true
 
-      - name: Download QCA/Iris SDKs
+      - name: Download QCA/Iris/QtKeychain SDKs
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          mkdir qca-sdk iris-sdk
+          mkdir qca-sdk iris-sdk qtkeychain-sdk
           gh release download "$QCA_TAG" --repo psi-im/qca \
             -p "qca3-qt6-android-${{ matrix.abi }}.zip" -O qca.zip
           gh release download "$IRIS_TAG" --repo psi-im/iris \
             -p "iris-qt6-android-${{ matrix.abi }}.zip" -O iris.zip
+          qtkeychain_asset="qtkeychain-${QTKEYCHAIN_VERSION}-${QTKEYCHAIN_REVISION}-qt6.11-android-${{ matrix.abi }}.tar.gz"
+          gh release download "$QTKEYCHAIN_TAG" --repo "$GITHUB_REPOSITORY" \
+            -p "$qtkeychain_asset" -O qtkeychain.tar.gz
           (cd qca-sdk && cmake -E tar xvf ../qca.zip)
           (cd iris-sdk && cmake -E tar xvf ../iris.zip)
+          tar -xzf qtkeychain.tar.gz -C qtkeychain-sdk
           test -d qca-sdk/lib/cmake/Qca3-qt6
           test -d iris-sdk/lib/cmake/Iris
+          test -f qtkeychain-sdk/lib/cmake/Qt6Keychain/Qt6KeychainConfig.cmake
+          test -f qtkeychain-sdk/lib/libqt6keychain.a
 
       - name: Provision Android OpenSSL
         shell: bash
@@ -538,11 +559,12 @@ jobs:
             -DANYKEEP_XMPP_BACKEND=IRIS \
             -DANYKEEP_QCA_SDK_ROOT="$PWD/qca-sdk" \
             -DANYKEEP_IRIS_SDK_ROOT="$PWD/iris-sdk" \
+            -DANYKEEP_QTKEYCHAIN_SDK_ROOT="$PWD/qtkeychain-sdk" \
             -DANYKEEP_BUILD_BUNDLED_QCA=OFF \
             -DANYKEEP_BUILD_BUNDLED_IRIS=OFF \
             -DANYKEEP_BUILD_BUNDLED_QXMPP=OFF \
             -DANYKEEP_BUILD_BUNDLED_QCORO=OFF \
-            -DANYKEEP_BUILD_BUNDLED_QTKEYCHAIN=ON \
+            -DANYKEEP_BUILD_BUNDLED_QTKEYCHAIN=OFF \
             -DANYKEEP_INSTALL_PREBUILT_SDK_RUNTIME=ON \
             -DANYKEEP_ANDROID_OPENSSL_ROOT="$PWD/android-openssl/ssl_3" \
             -DBUILD_TESTING=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,9 @@ set(ANYKEEP_QCA_SDK_ROOT
 set(ANYKEEP_IRIS_SDK_ROOT
     ""
     CACHE PATH "Root of a prebuilt Iris SDK; when set it takes precedence over the bundled Iris fallback")
+set(ANYKEEP_QTKEYCHAIN_SDK_ROOT
+    ""
+    CACHE PATH "Root of a prebuilt QtKeychain SDK; when set it takes precedence over installed/source fallbacks")
 option(ANYKEEP_INSTALL_PREBUILT_SDK_RUNTIME
        "Install/package runtime files from ANYKEEP_QCA_SDK_ROOT and ANYKEEP_IRIS_SDK_ROOT" OFF)
 option(ANYKEEP_BUILD_BUNDLED_QXMPP "Build bundled QXmpp when a suitable system QXmpp is unavailable"
@@ -166,7 +169,8 @@ else()
 endif()
 include(GNUInstallDirs)
 
-foreach(_anykeep_sdk_root IN ITEMS "${ANYKEEP_QCA_SDK_ROOT}" "${ANYKEEP_IRIS_SDK_ROOT}")
+foreach(_anykeep_sdk_root IN ITEMS "${ANYKEEP_QCA_SDK_ROOT}" "${ANYKEEP_IRIS_SDK_ROOT}"
+                                   "${ANYKEEP_QTKEYCHAIN_SDK_ROOT}")
   if(_anykeep_sdk_root)
     if(NOT IS_DIRECTORY "${_anykeep_sdk_root}")
       message(FATAL_ERROR "Configured AnyKeep SDK root does not exist: ${_anykeep_sdk_root}")
@@ -331,13 +335,33 @@ else()
   endif()
 endif()
 
-find_package(Qt6Keychain QUIET)
-if(NOT TARGET Qt6Keychain::Qt6Keychain AND ANYKEEP_BUILD_BUNDLED_QTKEYCHAIN
-   AND ANYKEEP_ALLOW_SOURCE_DEPENDENCY_FALLBACKS)
-  message(STATUS "System QtKeychain not found; using bundled QtKeychain")
-  include(BundledQtKeychain)
-elseif(NOT TARGET Qt6Keychain::Qt6Keychain AND ANYKEEP_BUILD_BUNDLED_QTKEYCHAIN)
-  message(STATUS "QtKeychain source fallback is disabled")
+if(ANYKEEP_QTKEYCHAIN_SDK_ROOT)
+  set(_anykeep_qtkeychain_package_dir "${ANYKEEP_QTKEYCHAIN_SDK_ROOT}/lib/cmake/Qt6Keychain")
+  if(NOT EXISTS "${_anykeep_qtkeychain_package_dir}/Qt6KeychainConfig.cmake")
+    message(FATAL_ERROR "QtKeychain SDK CMake package missing: ${_anykeep_qtkeychain_package_dir}")
+  endif()
+  # Android's Qt toolchain normally re-roots package searches. The SDK lives
+  # outside that sysroot, so keep this explicit package lookup unrooted.
+  find_package(Qt6Keychain CONFIG REQUIRED
+               PATHS "${_anykeep_qtkeychain_package_dir}"
+               NO_DEFAULT_PATH
+               NO_CMAKE_FIND_ROOT_PATH)
+  if(NOT TARGET Qt6Keychain::Qt6Keychain)
+    message(FATAL_ERROR
+            "QtKeychain SDK did not provide Qt6Keychain::Qt6Keychain: ${ANYKEEP_QTKEYCHAIN_SDK_ROOT}")
+  endif()
+  message(STATUS "QtKeychain: using prebuilt SDK (${ANYKEEP_QTKEYCHAIN_SDK_ROOT})")
+  unset(_anykeep_qtkeychain_package_dir)
+else()
+  find_package(Qt6Keychain QUIET)
+  if(TARGET Qt6Keychain::Qt6Keychain)
+    message(STATUS "QtKeychain: using installed package")
+  elseif(ANYKEEP_BUILD_BUNDLED_QTKEYCHAIN AND ANYKEEP_ALLOW_SOURCE_DEPENDENCY_FALLBACKS)
+    message(STATUS "System QtKeychain not found; using bundled QtKeychain")
+    include(BundledQtKeychain)
+  elseif(ANYKEEP_BUILD_BUNDLED_QTKEYCHAIN)
+    message(STATUS "QtKeychain source fallback is disabled")
+  endif()
 endif()
 
 # QSourceHighlite is tiny and MIT-licensed, so keep the pinned source in-tree


### PR DESCRIPTION
Finish the QtKeychain dependency-bundle integration on top of current master.

- add ANYKEEP_QTKEYCHAIN_SDK_ROOT with Android-safe package lookup
- consume the prebuilt SDK in Windows and macOS CI
- consume the prebuilt SDK in Windows/macOS/Android packaging
- keep Linux on the system qtkeychain-qt6-dev package
- keep Android package builds to arm64-v8a and x86_64 and use the current all_os Qt Android repository

This is one code commit based directly on master.