### PR TITLE
Add inline date elements

### DIFF
--- a/libanykeep/anykeep.cpp
+++ b/libanykeep/anykeep.cpp
@@ -77,6 +77,26 @@ namespace AnyKeep {
 
 Q_LOGGING_CATEGORY(logMain, "anykeep.main")
 
+namespace {
+    NoteDialog *findOpenNoteDialog(const Note &note, const QUuid &draftId = {})
+    {
+        // The id used to start an asynchronous load is not necessarily the
+        // canonical id carried by its result (remote storages may resolve an
+        // alias while loading). Always deduplicate by the loaded Note first.
+        if (!note.id().isEmpty()) {
+            if (auto *dialog = NoteDialog::findDialog(note.storageId(), note.id()))
+                return dialog;
+        }
+        if (draftId.isNull())
+            return nullptr;
+        for (auto *dialog : NoteDialog::openDialogs()) {
+            if (dialog && dialog->editor() && dialog->editor()->draftId() == draftId)
+                return dialog;
+        }
+        return nullptr;
+    }
+}
+
 class Main::Private : public QObject {
     Q_OBJECT
 
@@ -315,7 +335,9 @@ Main::Main(QObject *parent) : QObject(parent), d(new Private(this)), _inited(fal
             note.setFolderId(draft.folderId);
             note.setMedia(draft.media);
             note.setBackendData(draft.backendData);
-            auto *dialog = new NoteDialog(note, this, draft.id);
+            auto *dialog = findOpenNoteDialog(note, draft.id);
+            if (!dialog)
+                dialog = new NoteDialog(note, this, draft.id);
             d->recoveredDraftIds.insert(draft.id);
             dialog->show();
         }
@@ -715,9 +737,10 @@ void Main::restoreUpdateSessionForStorage(const QString &storageId)
                     job->deleteLater();
                     return;
                 }
-                auto *dialog = NoteDialog::findDialog(entry.storageId, entry.noteId);
+                const auto loaded = job->result();
+                auto      *dialog = findOpenNoteDialog(loaded, entry.draftId);
                 if (!dialog)
-                    dialog = new NoteDialog(job->result(), this);
+                    dialog = new NoteDialog(loaded, this, entry.draftId);
                 if (entry.geometry.isValid()) {
                     dialog->setGeometry(
                         WindowGeometryUtils::constrainToCurrentScreens(entry.geometry, dialog->minimumSize()));
@@ -1082,7 +1105,9 @@ void Main::openNoteDialog(const QString &storageId, const QString &noteId)
                 notifyError(tr("The draft could not be opened"));
                 return;
             }
-            auto *dialog = new NoteDialog(note, this, draftId);
+            auto *dialog = findOpenNoteDialog(note, draftId);
+            if (!dialog)
+                dialog = new NoteDialog(note, this, draftId);
             dialog->show();
             activateWindow(dialog);
             return;
@@ -1090,15 +1115,16 @@ void Main::openNoteDialog(const QString &storageId, const QString &noteId)
         const QString effectiveStorageId = storage->systemName();
         const QString effectiveNoteId    = resumed.value.remoteNoteId;
         auto         *job = NoteManager::instance()->loadNoteAsync(effectiveStorageId, effectiveNoteId, this);
-        connect(job, &StorageJob::finished, this, [this, job, draftId, effectiveStorageId, effectiveNoteId]() {
+        connect(job, &StorageJob::finished, this, [this, job, draftId]() {
             if (job->state() != StorageJob::Succeeded) {
                 notifyError(job->error().message.isEmpty() ? tr("Failed to load note") : job->error().message);
                 job->deleteLater();
                 return;
             }
-            auto *dialog = NoteDialog::findDialog(effectiveStorageId, effectiveNoteId);
+            const auto loaded = job->result();
+            auto      *dialog = findOpenNoteDialog(loaded, draftId);
             if (!dialog)
-                dialog = new NoteDialog(job->result(), this, draftId);
+                dialog = new NoteDialog(loaded, this, draftId);
             dialog->show();
             activateWindow(dialog);
             job->deleteLater();
@@ -1149,7 +1175,9 @@ void Main::openNoteDialog(const QString &storageId, const QString &noteId)
                 notifyError(tr("The pending draft could not be opened"));
                 return;
             }
-            auto *dialog = new NoteDialog(note, this, draftId);
+            auto *dialog = findOpenNoteDialog(note, draftId);
+            if (!dialog)
+                dialog = new NoteDialog(note, this, draftId);
             dialog->show();
             activateWindow(dialog);
             return;
@@ -1159,15 +1187,16 @@ void Main::openNoteDialog(const QString &storageId, const QString &noteId)
     const QString effectiveStorageId = pending ? pending.value.storageId : storageId;
     const QString effectiveNoteId    = pending ? pending.value.remoteNoteId : noteId;
     auto         *job = NoteManager::instance()->loadNoteAsync(effectiveStorageId, effectiveNoteId, this);
-    connect(job, &StorageJob::finished, this, [this, job, effectiveStorageId, effectiveNoteId, draftId]() {
+    connect(job, &StorageJob::finished, this, [this, job, draftId]() {
         if (job->state() != StorageJob::Succeeded) {
             notifyError(job->error().message.isEmpty() ? tr("Failed to load note") : job->error().message);
             job->deleteLater();
             return;
         }
-        auto *dlg = NoteDialog::findDialog(effectiveStorageId, effectiveNoteId);
+        const auto loaded = job->result();
+        auto      *dlg    = findOpenNoteDialog(loaded, draftId);
         if (!dlg)
-            dlg = new NoteDialog(job->result(), this, draftId);
+            dlg = new NoteDialog(loaded, this, draftId);
         dlg->show();
         activateWindow(dlg);
         job->deleteLater();

--- a/libanykeep/drafts/publication.cpp
+++ b/libanykeep/drafts/publication.cpp
@@ -193,8 +193,15 @@ QList<DraftRecord> DraftManager::recoverableDrafts() const
     if (!records)
         return result;
     for (const auto &record : records.value) {
-        if (record.operation == DraftRecord::Publish && record.state == DraftRecord::Editing)
+        // Editing records are crash-recovery candidates only when no editor in
+        // this process currently owns them. A storage may finish initializing
+        // after its cached note has already been opened and checkpointed; in
+        // that case treating the live session as recoverable would open the
+        // same note a second time from Main's storageReady handler.
+        if (record.operation == DraftRecord::Publish && record.state == DraftRecord::Editing
+            && !editingSessions_.contains(record.id)) {
             result.push_back(record);
+        }
     }
     qCInfo(logDraftPersistence) << "Recoverable editing drafts:" << result.size();
     return result;

--- a/libanykeep/main.qrc
+++ b/libanykeep/main.qrc
@@ -56,6 +56,9 @@
         <file alias="editor/controllers/EditorFocusController.qml">qml/editor/controllers/EditorFocusController.qml</file>
         <file alias="editor/controllers/EditorMediaNavigationController.qml">qml/editor/controllers/EditorMediaNavigationController.qml</file>
         <file alias="editor/controllers/EditorSelectionController.qml">qml/editor/controllers/EditorSelectionController.qml</file>
+        <file alias="editor/components/DateChip.qml">qml/editor/components/DateChip.qml</file>
+        <file alias="editor/components/DatePickerPopup.qml">qml/editor/components/DatePickerPopup.qml</file>
+        <file alias="editor/components/InlineElementLayer.qml">qml/editor/components/InlineElementLayer.qml</file>
         <file alias="editor/components/NoteBlockTextArea.qml">qml/editor/components/NoteBlockTextArea.qml</file>
         <file alias="editor/NoteEditorPaneImpl.qml">qml/editor/NoteEditorPaneImpl.qml</file>
         <file alias="editor/NoteFindBar.qml">qml/editor/NoteFindBar.qml</file>

--- a/libanykeep/qml/editor/components/DateChip.qml
+++ b/libanykeep/qml/editor/components/DateChip.qml
@@ -12,22 +12,22 @@ Item {
 
     function backgroundColor(hovered) {
         if (urgencyState === "overdue")
-            return hovered ? "#f27d7d" : "#ef6c6c"
+            return hovered ? "#ef5350" : "#e53935"
         if (urgencyState === "soon")
             return hovered ? "#ffe082" : "#ffd54f"
-        return hovered ? "#93d497" : "#81c784"
+        return hovered ? "#66bb6a" : "#43a047"
     }
 
     function borderColor() {
         if (urgencyState === "overdue")
-            return "#b94343"
+            return "#b71c1c"
         if (urgencyState === "soon")
             return "#c59a17"
-        return "#4f8f58"
+        return "#2e7d32"
     }
 
     function foregroundColor() {
-        return "#1a1a1a"
+        return urgencyState === "soon" ? "#1a1a1a" : "#ffffff"
     }
 
     function segmentsForRange() {
@@ -89,20 +89,17 @@ Item {
     }
 
     readonly property var segments: segmentsForRange()
-    readonly property bool caretImmediatelyAfter: editor.activeFocus
-                                                 && editor.selectionStart === editor.selectionEnd
-                                                 && editor.cursorPosition === element.end
 
     Repeater {
         model: root.segments
         delegate: Rectangle {
             id: segmentBackground
             required property var modelData
-            readonly property real horizontalPadding: root.editor.editorView.touchMode ? 4 : 3.5
-            readonly property real rightPadding: root.caretImmediatelyAfter ? 0 : horizontalPadding
-            x: modelData.x - horizontalPadding
+            // Stay inside the QTextDocument range. Extending a chip into the
+            // neighbouring space hides both the visual gap and its caret.
+            x: modelData.x
             y: modelData.y
-            width: modelData.width + horizontalPadding + rightPadding
+            width: modelData.width
             height: Math.max(2, modelData.height)
             radius: Math.min(6, height / 3)
             color: root.backgroundColor(segmentMouse.containsMouse)
@@ -111,12 +108,14 @@ Item {
 
             Text {
                 anchors.fill: parent
-                leftPadding: segmentBackground.horizontalPadding
-                rightPadding: segmentBackground.rightPadding
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
                 text: root.editor.getText(parent.modelData.start, parent.modelData.end)
                 font: root.editor.font
+                // The layout width is still the ten source characters. A
+                // slightly compact label creates real visual padding without
+                // stealing width from surrounding Markdown whitespace.
+                scale: root.editor.editorView.touchMode ? 0.94 : 0.92
                 color: root.foregroundColor()
                 elide: Text.ElideNone
             }

--- a/libanykeep/qml/editor/components/DateChip.qml
+++ b/libanykeep/qml/editor/components/DateChip.qml
@@ -10,32 +10,24 @@ Item {
 
     anchors.fill: parent
 
-    function paletteIsDark() {
-        const base = editor.palette.base
-        return 0.299 * base.r + 0.587 * base.g + 0.114 * base.b < 0.5
-    }
-
-    function statusColor() {
-        const dark = paletteIsDark()
-        if (urgencyState === "overdue")
-            return dark ? Qt.rgba(0.973, 0.318, 0.286, 1) : Qt.rgba(0.812, 0.133, 0.180, 1)
-        if (urgencyState === "soon")
-            return dark ? Qt.rgba(0.824, 0.600, 0.133, 1) : Qt.rgba(0.604, 0.404, 0.000, 1)
-        return dark ? Qt.rgba(0.247, 0.725, 0.314, 1) : Qt.rgba(0.102, 0.498, 0.216, 1)
-    }
-
     function backgroundColor(hovered) {
-        const base = statusColor()
-        const dark = paletteIsDark()
-        return Qt.rgba(base.r, base.g, base.b,
-                       hovered ? (dark ? 0.24 : 0.16) : (dark ? 0.16 : 0.10))
+        if (urgencyState === "overdue")
+            return hovered ? "#f27d7d" : "#ef6c6c"
+        if (urgencyState === "soon")
+            return hovered ? "#ffe082" : "#ffd54f"
+        return hovered ? "#93d497" : "#81c784"
     }
 
-    function borderColor(hovered) {
-        const base = statusColor()
-        const dark = paletteIsDark()
-        return Qt.rgba(base.r, base.g, base.b,
-                       hovered ? (dark ? 0.72 : 0.55) : (dark ? 0.46 : 0.34))
+    function borderColor() {
+        if (urgencyState === "overdue")
+            return "#b94343"
+        if (urgencyState === "soon")
+            return "#c59a17"
+        return "#4f8f58"
+    }
+
+    function foregroundColor() {
+        return "#1a1a1a"
     }
 
     function segmentsForRange() {
@@ -73,11 +65,14 @@ Item {
                     x: current.x,
                     y: current.y,
                     right: right,
-                    height: current.height
+                    height: current.height,
+                    start: position,
+                    end: position + 1
                 }
             } else {
                 segment.right = Math.max(segment.right, right)
                 segment.height = Math.max(segment.height, current.height)
+                segment.end = position + 1
             }
 
             if (!sameLine || position === element.end - 1) {
@@ -103,16 +98,28 @@ Item {
         delegate: Rectangle {
             id: segmentBackground
             required property var modelData
-            readonly property real leftExtra: root.editor.editorView.touchMode ? 2.5 : 2
-            readonly property real rightExtra: root.caretImmediatelyAfter ? 0 : leftExtra
-            x: modelData.x - leftExtra
-            y: modelData.y + 1
-            width: modelData.width + leftExtra + rightExtra
-            height: Math.max(2, modelData.height - 2)
+            readonly property real horizontalPadding: root.editor.editorView.touchMode ? 4 : 3.5
+            readonly property real rightPadding: root.caretImmediatelyAfter ? 0 : horizontalPadding
+            x: modelData.x - horizontalPadding
+            y: modelData.y
+            width: modelData.width + horizontalPadding + rightPadding
+            height: Math.max(2, modelData.height)
             radius: Math.min(6, height / 3)
             color: root.backgroundColor(segmentMouse.containsMouse)
-            border.color: root.borderColor(segmentMouse.containsMouse)
+            border.color: root.borderColor()
             border.width: 1
+
+            Text {
+                anchors.fill: parent
+                leftPadding: segmentBackground.horizontalPadding
+                rightPadding: segmentBackground.rightPadding
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                text: root.editor.getText(parent.modelData.start, parent.modelData.end)
+                font: root.editor.font
+                color: root.foregroundColor()
+                elide: Text.ElideNone
+            }
 
             MouseArea {
                 id: segmentMouse

--- a/libanykeep/qml/editor/components/DateChip.qml
+++ b/libanykeep/qml/editor/components/DateChip.qml
@@ -94,16 +94,20 @@ Item {
     }
 
     readonly property var segments: segmentsForRange()
+    readonly property bool caretImmediatelyAfter: editor.activeFocus
+                                                 && editor.selectionStart === editor.selectionEnd
+                                                 && editor.cursorPosition === element.end
 
     Repeater {
         model: root.segments
         delegate: Rectangle {
             id: segmentBackground
             required property var modelData
-            readonly property real horizontalPadding: root.editor.editorView.touchMode ? 2.5 : 2
-            x: modelData.x - horizontalPadding
+            readonly property real leftExtra: root.editor.editorView.touchMode ? 2.5 : 2
+            readonly property real rightExtra: root.caretImmediatelyAfter ? 0 : leftExtra
+            x: modelData.x - leftExtra
             y: modelData.y + 1
-            width: modelData.width + 2 * horizontalPadding
+            width: modelData.width + leftExtra + rightExtra
             height: Math.max(2, modelData.height - 2)
             radius: Math.min(6, height / 3)
             color: root.backgroundColor(segmentMouse.containsMouse)

--- a/libanykeep/qml/editor/components/DateChip.qml
+++ b/libanykeep/qml/editor/components/DateChip.qml
@@ -1,0 +1,119 @@
+import QtQuick
+
+Item {
+    id: root
+    required property var editor
+    required property var element
+    required property string urgencyState
+    required property int layoutRevision
+    signal activated()
+
+    anchors.fill: parent
+
+    function paletteIsDark() {
+        const base = editor.palette.base
+        return 0.299 * base.r + 0.587 * base.g + 0.114 * base.b < 0.5
+    }
+
+    function backgroundColor(hovered) {
+        const dark = paletteIsDark()
+        const alpha = hovered ? (dark ? 0.42 : 0.34) : (dark ? 0.30 : 0.23)
+        if (urgencyState === "overdue")
+            return Qt.rgba(dark ? 0.95 : 0.82, dark ? 0.31 : 0.16, dark ? 0.31 : 0.14, alpha)
+        if (urgencyState === "soon")
+            return Qt.rgba(dark ? 0.96 : 0.93, dark ? 0.72 : 0.61, dark ? 0.20 : 0.08, alpha)
+        return Qt.rgba(dark ? 0.32 : 0.12, dark ? 0.78 : 0.62, dark ? 0.43 : 0.25, alpha)
+    }
+
+    function borderColor(hovered) {
+        const dark = paletteIsDark()
+        const alpha = hovered ? 0.72 : 0.48
+        if (urgencyState === "overdue")
+            return Qt.rgba(dark ? 1.0 : 0.72, dark ? 0.42 : 0.12, dark ? 0.42 : 0.10, alpha)
+        if (urgencyState === "soon")
+            return Qt.rgba(dark ? 1.0 : 0.78, dark ? 0.80 : 0.52, dark ? 0.30 : 0.04, alpha)
+        return Qt.rgba(dark ? 0.43 : 0.08, dark ? 0.88 : 0.52, dark ? 0.55 : 0.20, alpha)
+    }
+
+    function segmentsForRange() {
+        // These reads make the binding follow layout-affecting changes that do
+        // not alter the source range itself.
+        const revision = layoutRevision
+        const editorWidth = editor.width
+        const editorHeight = editor.height
+        const fontPointSize = editor.font.pointSize
+        void revision
+        void editorWidth
+        void editorHeight
+        void fontPointSize
+
+        if (!element || element.start < 0 || element.end <= element.start
+                || element.end > editor.length)
+            return []
+
+        const averageWidth = editor.editorView
+                ? editor.editorView.editorFontAverageCharacterWidth : 8
+        const segments = []
+        let segment = null
+        for (let position = element.start; position < element.end; ++position) {
+            const current = editor.positionToRectangle(position)
+            const next = editor.positionToRectangle(position + 1)
+            const sameLine = Math.abs(next.y - current.y) < 0.5
+            const right = sameLine && next.x > current.x
+                    ? next.x
+                    : current.x + Math.max(current.width, averageWidth)
+
+            if (!segment || Math.abs(segment.y - current.y) >= 0.5) {
+                if (segment)
+                    segments.push(segment)
+                segment = {
+                    x: current.x,
+                    y: current.y,
+                    right: right,
+                    height: current.height
+                }
+            } else {
+                segment.right = Math.max(segment.right, right)
+                segment.height = Math.max(segment.height, current.height)
+            }
+
+            if (!sameLine || position === element.end - 1) {
+                segments.push(segment)
+                segment = null
+            }
+        }
+        if (segment)
+            segments.push(segment)
+
+        for (const value of segments)
+            value.width = Math.max(1, value.right - value.x)
+        return segments
+    }
+
+    readonly property var segments: segmentsForRange()
+
+    Repeater {
+        model: root.segments
+        delegate: Rectangle {
+            id: segmentBackground
+            required property var modelData
+            x: modelData.x - 3
+            y: modelData.y + 1
+            width: modelData.width + 6
+            height: Math.max(2, modelData.height - 2)
+            radius: Math.min(6, height / 3)
+            color: root.backgroundColor(segmentMouse.containsMouse)
+            border.color: root.borderColor(segmentMouse.containsMouse)
+            border.width: 1
+
+            MouseArea {
+                id: segmentMouse
+                anchors.fill: parent
+                acceptedButtons: Qt.LeftButton
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.activated()
+            }
+        }
+    }
+}

--- a/libanykeep/qml/editor/components/DateChip.qml
+++ b/libanykeep/qml/editor/components/DateChip.qml
@@ -15,24 +15,27 @@ Item {
         return 0.299 * base.r + 0.587 * base.g + 0.114 * base.b < 0.5
     }
 
-    function backgroundColor(hovered) {
+    function statusColor() {
         const dark = paletteIsDark()
-        const alpha = hovered ? (dark ? 0.42 : 0.34) : (dark ? 0.30 : 0.23)
         if (urgencyState === "overdue")
-            return Qt.rgba(dark ? 0.95 : 0.82, dark ? 0.31 : 0.16, dark ? 0.31 : 0.14, alpha)
+            return dark ? Qt.rgba(0.973, 0.318, 0.286, 1) : Qt.rgba(0.812, 0.133, 0.180, 1)
         if (urgencyState === "soon")
-            return Qt.rgba(dark ? 0.96 : 0.93, dark ? 0.72 : 0.61, dark ? 0.20 : 0.08, alpha)
-        return Qt.rgba(dark ? 0.32 : 0.12, dark ? 0.78 : 0.62, dark ? 0.43 : 0.25, alpha)
+            return dark ? Qt.rgba(0.824, 0.600, 0.133, 1) : Qt.rgba(0.604, 0.404, 0.000, 1)
+        return dark ? Qt.rgba(0.247, 0.725, 0.314, 1) : Qt.rgba(0.102, 0.498, 0.216, 1)
+    }
+
+    function backgroundColor(hovered) {
+        const base = statusColor()
+        const dark = paletteIsDark()
+        return Qt.rgba(base.r, base.g, base.b,
+                       hovered ? (dark ? 0.24 : 0.16) : (dark ? 0.16 : 0.10))
     }
 
     function borderColor(hovered) {
+        const base = statusColor()
         const dark = paletteIsDark()
-        const alpha = hovered ? 0.72 : 0.48
-        if (urgencyState === "overdue")
-            return Qt.rgba(dark ? 1.0 : 0.72, dark ? 0.42 : 0.12, dark ? 0.42 : 0.10, alpha)
-        if (urgencyState === "soon")
-            return Qt.rgba(dark ? 1.0 : 0.78, dark ? 0.80 : 0.52, dark ? 0.30 : 0.04, alpha)
-        return Qt.rgba(dark ? 0.43 : 0.08, dark ? 0.88 : 0.52, dark ? 0.55 : 0.20, alpha)
+        return Qt.rgba(base.r, base.g, base.b,
+                       hovered ? (dark ? 0.72 : 0.55) : (dark ? 0.46 : 0.34))
     }
 
     function segmentsForRange() {
@@ -97,9 +100,10 @@ Item {
         delegate: Rectangle {
             id: segmentBackground
             required property var modelData
-            x: modelData.x - 3
+            readonly property real horizontalPadding: root.editor.editorView.touchMode ? 2.5 : 2
+            x: modelData.x - horizontalPadding
             y: modelData.y + 1
-            width: modelData.width + 6
+            width: modelData.width + 2 * horizontalPadding
             height: Math.max(2, modelData.height - 2)
             radius: Math.min(6, height / 3)
             color: root.backgroundColor(segmentMouse.containsMouse)

--- a/libanykeep/qml/editor/components/DatePickerPopup.qml
+++ b/libanykeep/qml/editor/components/DatePickerPopup.qml
@@ -1,0 +1,159 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Popup {
+    id: root
+    required property var editorView
+    objectName: "inlineDatePickerPopup"
+    parent: Overlay.overlay
+    modal: false
+    focus: true
+    padding: editorView.touchMode ? 12 : 8
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    width: editorView.touchMode
+           ? Math.max(280, parent ? Math.min(360, parent.width - 24) : 320)
+           : Math.max(280, parent ? Math.min(320, parent.width - 16) : 304)
+
+    property var editor: null
+    property int selectionStart: 0
+    property int selectionEnd: 0
+    property date selectedDate: new Date()
+    property int visibleMonth: selectedDate.getMonth()
+    property int visibleYear: selectedDate.getFullYear()
+    signal dateChosen(date value)
+
+    function normalizedDate(value) {
+        return new Date(value.getFullYear(), value.getMonth(), value.getDate())
+    }
+
+    function dateFromIso(value) {
+        const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value || ""))
+        if (!match)
+            return null
+        const year = Number(match[1])
+        const month = Number(match[2])
+        const day = Number(match[3])
+        if (year < 1 || month < 1 || month > 12 || day < 1 || day > 31)
+            return null
+        const result = new Date(0)
+        result.setHours(0, 0, 0, 0)
+        result.setFullYear(year, month - 1, day)
+        if (result.getFullYear() !== year || result.getMonth() !== month - 1
+                || result.getDate() !== day)
+            return null
+        return result
+    }
+
+    function sameDay(left, right) {
+        return left && right && left.getFullYear() === right.getFullYear()
+                && left.getMonth() === right.getMonth() && left.getDate() === right.getDate()
+    }
+
+    function shiftMonth(delta) {
+        const shifted = new Date(visibleYear, visibleMonth + delta, 1)
+        visibleYear = shifted.getFullYear()
+        visibleMonth = shifted.getMonth()
+    }
+
+    function positionForTarget(target, start) {
+        if (!target || !Overlay.overlay)
+            return
+        const rectangle = target.positionToRectangle(Math.max(0, start))
+        const point = target.mapToItem(Overlay.overlay, rectangle.x, rectangle.y + rectangle.height)
+        const inset = editorView.touchMode ? 12 : 8
+        x = Math.max(inset, Math.min(Overlay.overlay.width - width - inset, point.x))
+        const popupHeight = implicitHeight > 0 ? implicitHeight : 300
+        if (point.y + 6 + popupHeight <= Overlay.overlay.height - inset)
+            y = point.y + 6
+        else
+            y = Math.max(inset, point.y - rectangle.height - popupHeight - 6)
+    }
+
+    function openFor(target, start, end, dateText) {
+        editor = target
+        selectionStart = Math.max(0, Number(start))
+        selectionEnd = Math.max(selectionStart, Number(end))
+        const parsed = dateFromIso(dateText)
+        selectedDate = parsed ? parsed : normalizedDate(new Date())
+        visibleMonth = selectedDate.getMonth()
+        visibleYear = selectedDate.getFullYear()
+        open()
+        Qt.callLater(function() {
+            if (root.visible && root.editor)
+                root.positionForTarget(root.editor, root.selectionStart)
+        })
+    }
+
+    onClosed: {
+        if (editor)
+            editor.forceActiveFocus()
+    }
+
+    contentItem: ColumnLayout {
+        spacing: root.editorView.touchMode ? 8 : 5
+
+        RowLayout {
+            Layout.fillWidth: true
+            ToolButton {
+                text: "‹"
+                Layout.minimumWidth: root.editorView.touchMode ? 44 : 34
+                Layout.minimumHeight: root.editorView.touchMode ? 44 : 32
+                onClicked: root.shiftMonth(-1)
+            }
+            Label {
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                text: monthGrid.title
+                font.bold: true
+            }
+            ToolButton {
+                text: "›"
+                Layout.minimumWidth: root.editorView.touchMode ? 44 : 34
+                Layout.minimumHeight: root.editorView.touchMode ? 44 : 32
+                onClicked: root.shiftMonth(1)
+            }
+        }
+
+        DayOfWeekRow {
+            Layout.fillWidth: true
+            locale: monthGrid.locale
+        }
+
+        MonthGrid {
+            id: monthGrid
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.editorView.touchMode ? 252 : 210
+            month: root.visibleMonth
+            year: root.visibleYear
+            locale: Qt.locale()
+
+            delegate: Rectangle {
+                required property var model
+                implicitWidth: root.editorView.touchMode ? 42 : 36
+                implicitHeight: root.editorView.touchMode ? 40 : 32
+                radius: Math.min(width, height) / 2
+                color: root.sameDay(model.date, root.selectedDate)
+                       ? root.palette.highlight : "transparent"
+                border.width: model.today && !root.sameDay(model.date, root.selectedDate) ? 1 : 0
+                border.color: root.palette.highlight
+                opacity: model.month === monthGrid.month ? 1 : 0.35
+
+                Text {
+                    anchors.centerIn: parent
+                    text: parent.model.day
+                    font: monthGrid.font
+                    color: root.sameDay(parent.model.date, root.selectedDate)
+                           ? root.palette.highlightedText : root.palette.text
+                }
+            }
+
+            onClicked: function(date) {
+                root.selectedDate = root.normalizedDate(date)
+                root.dateChosen(root.selectedDate)
+                root.close()
+            }
+        }
+    }
+}

--- a/libanykeep/qml/editor/components/InlineElementLayer.qml
+++ b/libanykeep/qml/editor/components/InlineElementLayer.qml
@@ -16,6 +16,8 @@ Item {
     property bool inlineCaretOn: true
     property bool normalizingCursor: false
     property int lastCursorPosition: -1
+    property var delegatedKeyHandler: null
+    property var installedKeyHandler: null
 
     function startOfDay(value) {
         return new Date(value.getFullYear(), value.getMonth(), value.getDate())
@@ -126,28 +128,78 @@ Item {
         ++layoutRevision
     }
 
-    function insertTransientDateSeparator(position) {
+    function dateEndingAt(position) {
         if (!editor)
-            return false
+            return null
+        const value = Number(position)
         const plain = editor.currentPlainText()
-        const boundedPosition = Math.max(0, Math.min(plain.length, Number(position)))
-        if (boundedPosition !== plain.length)
+        for (const element of elements) {
+            if (!element || element.type !== "date" || element.end !== value)
+                continue
+            if (element.start < 0 || element.end > plain.length)
+                continue
+            if (plain.substring(element.start, element.end) === element.dateText)
+                return element
+        }
+        return null
+    }
+
+    function handleDateContinuationInput(event) {
+        if (!editor || !event || !editor.renderedMarkdown || editor.codeDocument
+                || editor.selectionStart !== editor.selectionEnd)
             return false
 
-        // Keep a normal separator in the live QTextDocument so the user can
-        // immediately continue typing after a shortcut date. Do not commit a
-        // trailing Markdown space by itself: the model already contains the
-        // date, and the next real character will commit "date text" normally.
-        const previousSyncing = Boolean(editor.syncingSourceText)
-        editor.syncingSourceText = true
-        try {
-            editor.insert(boundedPosition, " ")
-            editor.cursorPosition = boundedPosition + 1
-        } finally {
-            editor.syncingSourceText = previousSyncing
+        const input = String(event.text || "")
+        if (input.length === 0 || /[\u0000-\u001f\u007f\u2028\u2029]/.test(input)
+                || isDateBoundary(input))
+            return false
+
+        // Preserve ordinary shortcuts while still allowing printable AltGr
+        // input (Ctrl+Alt on several desktop platforms).
+        if (event.modifiers & Qt.MetaModifier)
+            return false
+        if ((event.modifiers & Qt.ControlModifier) && !(event.modifiers & Qt.AltModifier))
+            return false
+        if ((event.modifiers & Qt.AltModifier) && !(event.modifiers & Qt.ControlModifier))
+            return false
+
+        const position = Number(editor.cursorPosition)
+        if (!dateEndingAt(position))
+            return false
+
+        // Insert the separator and the first continuation character in one
+        // QTextDocument operation. There is never a trailing-space-only state
+        // for Markdown to normalize away, and the date never temporarily
+        // becomes "YYYY-MM-DDx".
+        const handled = editorView.runEditTransaction("continue-date", function() {
+            editor.insert(position, " " + input)
+            const inputStart = position + 1
+            const inputEnd = inputStart + input.length
+            editor.cursorPosition = inputEnd
+            if (typeof editor.hasPendingInlineStyle === "function"
+                    && typeof editor.applyPendingInlineStyle === "function"
+                    && editor.hasPendingInlineStyle()) {
+                editor.applyPendingInlineStyle(inputStart, inputEnd)
+            }
+            editor.commitText(false)
+            editor.rememberPlainText()
+            return true
+        })
+        if (handled)
+            Qt.callLater(root.refresh)
+        return Boolean(handled)
+    }
+
+    function installKeyHandler() {
+        if (!editor || installedKeyHandler)
+            return
+        delegatedKeyHandler = editor.keyHandler
+        installedKeyHandler = function(event) {
+            if (root.handleDateContinuationInput(event))
+                return true
+            return root.delegatedKeyHandler ? Boolean(root.delegatedKeyHandler(event)) : false
         }
-        editor.rememberPlainText()
-        return true
+        editor.keyHandler = installedKeyHandler
     }
 
     function dateAtCursor(position, backspace) {
@@ -339,13 +391,8 @@ Item {
             editor.rememberPlainText()
             return true
         })
-        if (handled) {
-            if (Boolean(addSeparator) && characterAfter.length === 0
-                    && suffix.length === 0 && existingSeparatorAdvance === 0) {
-                root.insertTransientDateSeparator(boundedStart + replacement.length)
-            }
+        if (handled)
             Qt.callLater(root.refresh)
-        }
         return Boolean(handled)
     }
 
@@ -382,6 +429,8 @@ Item {
         dateShortcutTimer.restart()
         return true
     }
+
+    Component.onCompleted: installKeyHandler()
 
     Timer {
         id: dateShortcutTimer

--- a/libanykeep/qml/editor/components/InlineElementLayer.qml
+++ b/libanykeep/qml/editor/components/InlineElementLayer.qml
@@ -13,8 +13,7 @@ Item {
     property date today: startOfDay(new Date())
     property int pendingDateShortcutStart: -1
     property bool datePickerAddsSeparator: false
-    property int pendingDateContinuationPosition: -1
-    property bool materializingDateSeparator: false
+    property bool repairingDateBoundary: false
     property bool inlineCaretOn: true
     property bool normalizingCursor: false
     property int lastCursorPosition: -1
@@ -128,35 +127,37 @@ Item {
         ++layoutRevision
     }
 
-    function materializePendingDateSeparator() {
-        if (!editor || materializingDateSeparator || pendingDateContinuationPosition < 0)
+    function repairDateBoundaryAfterInput() {
+        if (!editor || repairingDateBoundary || editor.selectionStart !== editor.selectionEnd)
             return false
-        if (!editor.activeFocus || editor.selectionStart !== editor.selectionEnd) {
-            pendingDateContinuationPosition = -1
-            return false
-        }
 
         const plain = editor.currentPlainText()
-        const position = pendingDateContinuationPosition
-        if (position >= plain.length)
-            return false
-
-        const characterAfterDate = plain.charAt(position)
-        if (isDateBoundary(characterAfterDate)) {
-            // The user supplied a real separator (space/newline) or typed
-            // punctuation that is already a valid standalone-date boundary.
-            pendingDateContinuationPosition = -1
-            return false
-        }
-
         const cursor = Number(editor.cursorPosition)
-        pendingDateContinuationPosition = -1
-        materializingDateSeparator = true
-        editor.insert(position, " ")
-        if (cursor >= position)
-            editor.cursorPosition = cursor + 1
-        materializingDateSeparator = false
-        return true
+        for (const element of elements) {
+            if (!element || element.type !== "date"
+                    || element.start < 0 || element.end > plain.length)
+                continue
+            if (plain.substring(element.start, element.end) !== element.dateText)
+                continue
+
+            const characterAfterDate = element.end < plain.length ? plain.charAt(element.end) : ""
+            if (!characterAfterDate || isDateBoundary(characterAfterDate))
+                continue
+
+            // TextArea may emit textChanged immediately before or immediately
+            // after advancing the cursor for the newly typed character. Limit
+            // the repair to input that happened exactly at the widget edge.
+            if (cursor !== element.end && cursor !== element.end + 1)
+                continue
+
+            repairingDateBoundary = true
+            editor.insert(element.end, " ")
+            if (cursor >= element.end)
+                editor.cursorPosition = cursor + 1
+            repairingDateBoundary = false
+            return true
+        }
+        return false
     }
 
     function dateAtCursor(position, backspace) {
@@ -339,7 +340,6 @@ Item {
                 suffix = " "
         }
 
-        pendingDateContinuationPosition = -1
         const handled = editorView.runEditTransaction("set-date", function() {
             editor.remove(boundedStart, boundedEnd)
             editor.insert(boundedStart, replacement + suffix)
@@ -349,15 +349,8 @@ Item {
             editor.rememberPlainText()
             return true
         })
-        if (handled) {
-            // At EOL (or immediately before punctuation/newline) a literal
-            // trailing space would be normalized away. Remember the widget
-            // boundary instead and materialize a separator only if the next
-            // actual input is ordinary text.
-            if (Boolean(addSeparator) && suffix.length === 0 && existingSeparatorAdvance === 0)
-                pendingDateContinuationPosition = boundedStart + replacement.length
+        if (handled)
             Qt.callLater(root.refresh)
-        }
         return Boolean(handled)
     }
 
@@ -437,8 +430,8 @@ Item {
         target: root.editor
         ignoreUnknownSignals: true
         function onTextChanged() {
-            if (!root.materializingDateSeparator && root.pendingDateContinuationPosition >= 0)
-                Qt.callLater(root.materializePendingDateSeparator)
+            if (!root.repairingDateBoundary)
+                root.repairDateBoundaryAfterInput()
         }
         function onCursorPositionChanged() {
             if (!root.normalizingCursor)
@@ -452,8 +445,6 @@ Item {
             if (root.editor && root.editor.activeFocus) {
                 root.lastCursorPosition = Number(root.editor.cursorPosition)
                 Qt.callLater(root.normalizeCursorAndSelection)
-            } else {
-                root.pendingDateContinuationPosition = -1
             }
         }
     }

--- a/libanykeep/qml/editor/components/InlineElementLayer.qml
+++ b/libanykeep/qml/editor/components/InlineElementLayer.qml
@@ -13,6 +13,8 @@ Item {
     property date today: startOfDay(new Date())
     property int pendingDateShortcutStart: -1
     property bool datePickerAddsSeparator: false
+    property int pendingDateContinuationPosition: -1
+    property bool materializingDateSeparator: false
     property bool inlineCaretOn: true
     property bool normalizingCursor: false
     property int lastCursorPosition: -1
@@ -124,6 +126,37 @@ Item {
 
     function invalidateGeometry() {
         ++layoutRevision
+    }
+
+    function materializePendingDateSeparator() {
+        if (!editor || materializingDateSeparator || pendingDateContinuationPosition < 0)
+            return false
+        if (!editor.activeFocus || editor.selectionStart !== editor.selectionEnd) {
+            pendingDateContinuationPosition = -1
+            return false
+        }
+
+        const plain = editor.currentPlainText()
+        const position = pendingDateContinuationPosition
+        if (position >= plain.length)
+            return false
+
+        const characterAfterDate = plain.charAt(position)
+        if (isDateBoundary(characterAfterDate)) {
+            // The user supplied a real separator (space/newline) or typed
+            // punctuation that is already a valid standalone-date boundary.
+            pendingDateContinuationPosition = -1
+            return false
+        }
+
+        const cursor = Number(editor.cursorPosition)
+        pendingDateContinuationPosition = -1
+        materializingDateSeparator = true
+        editor.insert(position, " ")
+        if (cursor >= position)
+            editor.cursorPosition = cursor + 1
+        materializingDateSeparator = false
+        return true
     }
 
     function dateAtCursor(position, backspace) {
@@ -306,6 +339,7 @@ Item {
                 suffix = " "
         }
 
+        pendingDateContinuationPosition = -1
         const handled = editorView.runEditTransaction("set-date", function() {
             editor.remove(boundedStart, boundedEnd)
             editor.insert(boundedStart, replacement + suffix)
@@ -315,8 +349,15 @@ Item {
             editor.rememberPlainText()
             return true
         })
-        if (handled)
+        if (handled) {
+            // At EOL (or immediately before punctuation/newline) a literal
+            // trailing space would be normalized away. Remember the widget
+            // boundary instead and materialize a separator only if the next
+            // actual input is ordinary text.
+            if (Boolean(addSeparator) && suffix.length === 0 && existingSeparatorAdvance === 0)
+                pendingDateContinuationPosition = boundedStart + replacement.length
             Qt.callLater(root.refresh)
+        }
         return Boolean(handled)
     }
 
@@ -395,6 +436,10 @@ Item {
     Connections {
         target: root.editor
         ignoreUnknownSignals: true
+        function onTextChanged() {
+            if (!root.materializingDateSeparator && root.pendingDateContinuationPosition >= 0)
+                Qt.callLater(root.materializePendingDateSeparator)
+        }
         function onCursorPositionChanged() {
             if (!root.normalizingCursor)
                 root.normalizeCursorAndSelection()
@@ -407,6 +452,8 @@ Item {
             if (root.editor && root.editor.activeFocus) {
                 root.lastCursorPosition = Number(root.editor.cursorPosition)
                 Qt.callLater(root.normalizeCursorAndSelection)
+            } else {
+                root.pendingDateContinuationPosition = -1
             }
         }
     }

--- a/libanykeep/qml/editor/components/InlineElementLayer.qml
+++ b/libanykeep/qml/editor/components/InlineElementLayer.qml
@@ -13,7 +13,6 @@ Item {
     property date today: startOfDay(new Date())
     property int pendingDateShortcutStart: -1
     property bool datePickerAddsSeparator: false
-    property bool repairingDateBoundary: false
     property bool inlineCaretOn: true
     property bool normalizingCursor: false
     property int lastCursorPosition: -1
@@ -127,37 +126,28 @@ Item {
         ++layoutRevision
     }
 
-    function repairDateBoundaryAfterInput() {
-        if (!editor || repairingDateBoundary || editor.selectionStart !== editor.selectionEnd)
+    function insertTransientDateSeparator(position) {
+        if (!editor)
+            return false
+        const plain = editor.currentPlainText()
+        const boundedPosition = Math.max(0, Math.min(plain.length, Number(position)))
+        if (boundedPosition !== plain.length)
             return false
 
-        const plain = editor.currentPlainText()
-        const cursor = Number(editor.cursorPosition)
-        for (const element of elements) {
-            if (!element || element.type !== "date"
-                    || element.start < 0 || element.end > plain.length)
-                continue
-            if (plain.substring(element.start, element.end) !== element.dateText)
-                continue
-
-            const characterAfterDate = element.end < plain.length ? plain.charAt(element.end) : ""
-            if (!characterAfterDate || isDateBoundary(characterAfterDate))
-                continue
-
-            // TextArea may emit textChanged immediately before or immediately
-            // after advancing the cursor for the newly typed character. Limit
-            // the repair to input that happened exactly at the widget edge.
-            if (cursor !== element.end && cursor !== element.end + 1)
-                continue
-
-            repairingDateBoundary = true
-            editor.insert(element.end, " ")
-            if (cursor >= element.end)
-                editor.cursorPosition = cursor + 1
-            repairingDateBoundary = false
-            return true
+        // Keep a normal separator in the live QTextDocument so the user can
+        // immediately continue typing after a shortcut date. Do not commit a
+        // trailing Markdown space by itself: the model already contains the
+        // date, and the next real character will commit "date text" normally.
+        const previousSyncing = Boolean(editor.syncingSourceText)
+        editor.syncingSourceText = true
+        try {
+            editor.insert(boundedPosition, " ")
+            editor.cursorPosition = boundedPosition + 1
+        } finally {
+            editor.syncingSourceText = previousSyncing
         }
-        return false
+        editor.rememberPlainText()
+        return true
     }
 
     function dateAtCursor(position, backspace) {
@@ -349,8 +339,13 @@ Item {
             editor.rememberPlainText()
             return true
         })
-        if (handled)
+        if (handled) {
+            if (Boolean(addSeparator) && characterAfter.length === 0
+                    && suffix.length === 0 && existingSeparatorAdvance === 0) {
+                root.insertTransientDateSeparator(boundedStart + replacement.length)
+            }
             Qt.callLater(root.refresh)
+        }
         return Boolean(handled)
     }
 
@@ -429,10 +424,6 @@ Item {
     Connections {
         target: root.editor
         ignoreUnknownSignals: true
-        function onTextChanged() {
-            if (!root.repairingDateBoundary)
-                root.repairDateBoundaryAfterInput()
-        }
         function onCursorPositionChanged() {
             if (!root.normalizingCursor)
                 root.normalizeCursorAndSelection()

--- a/libanykeep/qml/editor/components/InlineElementLayer.qml
+++ b/libanykeep/qml/editor/components/InlineElementLayer.qml
@@ -12,6 +12,7 @@ Item {
     property int layoutRevision: 0
     property date today: startOfDay(new Date())
     property int pendingDateShortcutStart: -1
+    property bool datePickerAddsSeparator: false
 
     function startOfDay(value) {
         return new Date(value.getFullYear(), value.getMonth(), value.getDate())
@@ -125,6 +126,9 @@ Item {
                 if (position === element.end
                         || (position > element.start && position < element.end))
                     return element
+                if (editor && position === element.end + 1
+                        && editor.getText(element.end, element.end + 1) === " ")
+                    return element
             } else if (position === element.start
                        || (position > element.start && position < element.end)) {
                 return element
@@ -139,8 +143,13 @@ Item {
         const element = dateAtCursor(editor.cursorPosition, Boolean(backspace))
         if (!element)
             return false
+        let deleteEnd = element.end
+        if (Boolean(backspace) && editor.cursorPosition === element.end + 1
+                && editor.getText(element.end, element.end + 1) === " ") {
+            deleteEnd = element.end + 1
+        }
         const handled = editorView.runEditTransaction("delete-date", function() {
-            editor.remove(element.start, element.end)
+            editor.remove(element.start, deleteEnd)
             editor.cursorPosition = element.start
             editor.commitText(false)
             editor.rememberPlainText()
@@ -151,15 +160,30 @@ Item {
         return Boolean(handled)
     }
 
-    function replaceRangeWithDate(start, end, value) {
+    function replaceRangeWithDate(start, end, value, addSeparator) {
         const date = startOfDay(value)
         const replacement = isoDate(date)
         const boundedStart = Math.max(0, Math.min(editor.length, Number(start)))
         const boundedEnd = Math.max(boundedStart, Math.min(editor.length, Number(end)))
+        const characterAfter = boundedEnd < editor.length
+                ? editor.getText(boundedEnd, boundedEnd + 1) : ""
+        let suffix = ""
+        let existingSeparatorAdvance = 0
+        if (Boolean(addSeparator)) {
+            if (characterAfter === " " || characterAfter === "\t")
+                existingSeparatorAdvance = 1
+            else if (characterAfter.length === 0)
+                suffix = " "
+            else if (characterAfter !== "\n" && characterAfter !== "\r"
+                     && ".,;:!?)]}".indexOf(characterAfter) < 0)
+                suffix = " "
+        }
+
         const handled = editorView.runEditTransaction("set-date", function() {
             editor.remove(boundedStart, boundedEnd)
-            editor.insert(boundedStart, replacement)
+            editor.insert(boundedStart, replacement + suffix)
             editor.cursorPosition = boundedStart + replacement.length
+                    + suffix.length + existingSeparatorAdvance
             editor.commitText(false)
             editor.rememberPlainText()
             return true
@@ -169,9 +193,10 @@ Item {
         return Boolean(handled)
     }
 
-    function openDatePicker(start, end, dateText) {
+    function openDatePicker(start, end, dateText, addSeparator) {
         if (!editor || !editor.renderedMarkdown || editor.codeDocument)
             return false
+        datePickerAddsSeparator = Boolean(addSeparator)
         datePicker.openFor(editor, start, end, dateText)
         return true
     }
@@ -213,7 +238,7 @@ Item {
                 return
             if (root.editor.getText(start, start + 2) !== "//")
                 return
-            root.openDatePicker(start, start + 2, "")
+            root.openDatePicker(start, start + 2, "", true)
         }
     }
 
@@ -241,7 +266,7 @@ Item {
                 element: parent.modelData
                 urgencyState: root.dateState(parent.modelData.dateText)
                 layoutRevision: root.layoutRevision
-                onActivated: root.openDatePicker(element.start, element.end, element.dateText)
+                onActivated: root.openDatePicker(element.start, element.end, element.dateText, false)
             }
         }
     }
@@ -250,7 +275,9 @@ Item {
         id: datePicker
         editorView: root.editorView
         onDateChosen: function(value) {
-            root.replaceRangeWithDate(datePicker.selectionStart, datePicker.selectionEnd, value)
+            root.replaceRangeWithDate(datePicker.selectionStart, datePicker.selectionEnd,
+                                      value, root.datePickerAddsSeparator)
         }
+        onClosed: root.datePickerAddsSeparator = false
     }
 }

--- a/libanykeep/qml/editor/components/InlineElementLayer.qml
+++ b/libanykeep/qml/editor/components/InlineElementLayer.qml
@@ -13,6 +13,7 @@ Item {
     property date today: startOfDay(new Date())
     property int pendingDateShortcutStart: -1
     property bool datePickerAddsSeparator: false
+    property bool inlineCaretOn: true
 
     function startOfDay(value) {
         return new Date(value.getFullYear(), value.getMonth(), value.getDate())
@@ -137,6 +138,58 @@ Item {
         return null
     }
 
+    function dateForNavigation(position, direction) {
+        for (const element of elements) {
+            if (!element || element.type !== "date")
+                continue
+            if (direction > 0 && position >= element.start && position < element.end)
+                return element
+            if (direction < 0 && position > element.start && position <= element.end)
+                return element
+        }
+        return null
+    }
+
+    function canMoveAcrossDate(direction) {
+        return editor && editor.activeFocus
+                && editor.selectionStart === editor.selectionEnd
+                && dateForNavigation(editor.cursorPosition, Number(direction)) !== null
+    }
+
+    function moveAcrossDate(direction) {
+        if (!editor || editor.selectionStart !== editor.selectionEnd)
+            return false
+        const step = Number(direction)
+        const element = dateForNavigation(editor.cursorPosition, step)
+        if (!element)
+            return false
+        editor.cursorPosition = step > 0 ? element.end : element.start
+        editorView.activeEditor = editor
+        inlineCaretOn = true
+        inlineCaretTimer.restart()
+        return true
+    }
+
+    function cursorTouchesDate() {
+        if (!editor || !editor.activeFocus || editor.selectionStart !== editor.selectionEnd)
+            return false
+        const position = editor.cursorPosition
+        for (const element of elements) {
+            if (element && element.type === "date"
+                    && position >= element.start && position <= element.end)
+                return true
+        }
+        return false
+    }
+
+    function currentCaretRectangle() {
+        const revision = layoutRevision
+        void revision
+        if (!editor)
+            return Qt.rect(0, 0, 0, 0)
+        return editor.positionToRectangle(editor.cursorPosition)
+    }
+
     function deleteDateAtCursor(backspace) {
         if (!editor || editor.selectionStart !== editor.selectionEnd)
             return false
@@ -227,6 +280,18 @@ Item {
         return true
     }
 
+    Shortcut {
+        sequence: "Left"
+        enabled: root.canMoveAcrossDate(-1)
+        onActivated: root.moveAcrossDate(-1)
+    }
+
+    Shortcut {
+        sequence: "Right"
+        enabled: root.canMoveAcrossDate(1)
+        onActivated: root.moveAcrossDate(1)
+    }
+
     Timer {
         id: dateShortcutTimer
         interval: 0
@@ -253,6 +318,31 @@ Item {
         }
     }
 
+    Timer {
+        id: inlineCaretTimer
+        interval: 500
+        repeat: true
+        running: root.cursorTouchesDate()
+        onRunningChanged: {
+            if (running)
+                root.inlineCaretOn = true
+        }
+        onTriggered: root.inlineCaretOn = !root.inlineCaretOn
+    }
+
+    Connections {
+        target: root.editor
+        ignoreUnknownSignals: true
+        function onCursorPositionChanged() {
+            root.inlineCaretOn = true
+            if (inlineCaretTimer.running)
+                inlineCaretTimer.restart()
+        }
+        function onActiveFocusChanged() {
+            root.inlineCaretOn = true
+        }
+    }
+
     Repeater {
         model: root.elements
         delegate: Item {
@@ -269,6 +359,17 @@ Item {
                 onActivated: root.openDatePicker(element.start, element.end, element.dateText, false)
             }
         }
+    }
+
+    Rectangle {
+        readonly property var caretGeometry: root.currentCaretRectangle()
+        z: 100
+        visible: root.cursorTouchesDate() && root.inlineCaretOn
+        x: caretGeometry.x
+        y: caretGeometry.y + 1
+        width: 1
+        height: Math.max(2, caretGeometry.height - 2)
+        color: root.editor ? root.editor.palette.text : "white"
     }
 
     DatePickerPopup {

--- a/libanykeep/qml/editor/components/InlineElementLayer.qml
+++ b/libanykeep/qml/editor/components/InlineElementLayer.qml
@@ -172,9 +172,14 @@ Item {
         // for Markdown to normalize away, and the date never temporarily
         // becomes "YYYY-MM-DDx".
         const handled = editorView.runEditTransaction("continue-date", function() {
-            editor.insert(position, " " + input)
+            // QQuickTextEdit::insert() discards a leading space at the end of
+            // a Markdown paragraph. Use the QTextCursor-backed plain-text
+            // primitive so the separator and input really are one insertion.
+            const inputEnd = editorView.editorBackend.insertPlainText(
+                                 editor.textDocument, position, position, " " + input)
+            if (inputEnd < 0)
+                return false
             const inputStart = position + 1
-            const inputEnd = inputStart + input.length
             editor.cursorPosition = inputEnd
             if (typeof editor.hasPendingInlineStyle === "function"
                     && typeof editor.applyPendingInlineStyle === "function"
@@ -383,10 +388,14 @@ Item {
         }
 
         const handled = editorView.runEditTransaction("set-date", function() {
-            editor.remove(boundedStart, boundedEnd)
-            editor.insert(boundedStart, replacement + suffix)
-            editor.cursorPosition = boundedStart + replacement.length
-                    + suffix.length + existingSeparatorAdvance
+            // This also preserves a separator suffix before existing text;
+            // QQuickTextEdit::insert() normalizes edge whitespace in Markdown.
+            const replacementEnd = editorView.editorBackend.insertPlainText(
+                                       editor.textDocument, boundedStart, boundedEnd,
+                                       replacement + suffix)
+            if (replacementEnd < 0)
+                return false
+            editor.cursorPosition = replacementEnd + existingSeparatorAdvance
             editor.commitText(false)
             editor.rememberPlainText()
             return true

--- a/libanykeep/qml/editor/components/InlineElementLayer.qml
+++ b/libanykeep/qml/editor/components/InlineElementLayer.qml
@@ -1,0 +1,256 @@
+import QtQuick
+
+Item {
+    id: root
+    required property var editor
+    required property var editorView
+    objectName: "inlineElementLayer"
+    anchors.fill: parent
+    z: 30
+
+    property var elements: []
+    property int layoutRevision: 0
+    property date today: startOfDay(new Date())
+    property int pendingDateShortcutStart: -1
+
+    function startOfDay(value) {
+        return new Date(value.getFullYear(), value.getMonth(), value.getDate())
+    }
+
+    function dateFromIso(value) {
+        const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value || ""))
+        if (!match)
+            return null
+        const year = Number(match[1])
+        const month = Number(match[2])
+        const day = Number(match[3])
+        if (year < 1 || month < 1 || month > 12 || day < 1 || day > 31)
+            return null
+        const result = new Date(0)
+        result.setHours(0, 0, 0, 0)
+        result.setFullYear(year, month - 1, day)
+        if (result.getFullYear() !== year || result.getMonth() !== month - 1
+                || result.getDate() !== day)
+            return null
+        return result
+    }
+
+    function paddedNumber(value, width) {
+        let result = String(value)
+        while (result.length < width)
+            result = "0" + result
+        return result
+    }
+
+    function isoDate(value) {
+        return paddedNumber(value.getFullYear(), 4)
+                + "-" + paddedNumber(value.getMonth() + 1, 2)
+                + "-" + paddedNumber(value.getDate(), 2)
+    }
+
+    function isDateBoundary(character) {
+        if (!character || character.length === 0)
+            return true
+        if (/\s/.test(character))
+            return true
+        return "()[]{}<>,.;:!?\"'“”‘’—–".indexOf(character) >= 0
+    }
+
+    function dateState(dateText) {
+        const value = dateFromIso(dateText)
+        if (!value)
+            return "future"
+        const dayNumber = function(date) {
+            return Math.floor(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / 86400000)
+        }
+        const delta = dayNumber(value) - dayNumber(today)
+        if (delta < 0)
+            return "overdue"
+        if (delta <= 7)
+            return "soon"
+        return "future"
+    }
+
+    function refresh() {
+        if (!editor || !editor.renderedMarkdown || editor.codeDocument
+                || !editorView || !editorView.editorBackend) {
+            elements = []
+            ++layoutRevision
+            return
+        }
+
+        const plain = editor.currentPlainText()
+        const pattern = /\d{4}-\d{2}-\d{2}/g
+        const discovered = []
+        let match
+        while ((match = pattern.exec(plain)) !== null) {
+            const start = match.index
+            const end = start + match[0].length
+            const before = start > 0 ? plain.charAt(start - 1) : ""
+            const after = end < plain.length ? plain.charAt(end) : ""
+            if (!isDateBoundary(before) || !isDateBoundary(after))
+                continue
+            if (!dateFromIso(match[0]))
+                continue
+
+            const link = editorView.editorBackend.linkInfo(editor.textDocument, start, end)
+            if (link && link.valid && link.href)
+                continue
+            // QTextCursor::charFormat() reports the format immediately before
+            // an insertion position, so probe one character into the date.
+            if (editorView.editorBackend.inlineFormatEnabled(
+                        editor.textDocument, Math.min(end, start + 1), "code"))
+                continue
+
+            discovered.push({
+                type: "date",
+                start: start,
+                end: end,
+                dateText: match[0]
+            })
+        }
+        elements = discovered
+        ++layoutRevision
+    }
+
+    function invalidateGeometry() {
+        ++layoutRevision
+    }
+
+    function dateAtCursor(position, backspace) {
+        for (const element of elements) {
+            if (!element || element.type !== "date")
+                continue
+            if (backspace) {
+                if (position === element.end
+                        || (position > element.start && position < element.end))
+                    return element
+            } else if (position === element.start
+                       || (position > element.start && position < element.end)) {
+                return element
+            }
+        }
+        return null
+    }
+
+    function deleteDateAtCursor(backspace) {
+        if (!editor || editor.selectionStart !== editor.selectionEnd)
+            return false
+        const element = dateAtCursor(editor.cursorPosition, Boolean(backspace))
+        if (!element)
+            return false
+        const handled = editorView.runEditTransaction("delete-date", function() {
+            editor.remove(element.start, element.end)
+            editor.cursorPosition = element.start
+            editor.commitText(false)
+            editor.rememberPlainText()
+            return true
+        })
+        if (handled)
+            Qt.callLater(root.refresh)
+        return Boolean(handled)
+    }
+
+    function replaceRangeWithDate(start, end, value) {
+        const date = startOfDay(value)
+        const replacement = isoDate(date)
+        const boundedStart = Math.max(0, Math.min(editor.length, Number(start)))
+        const boundedEnd = Math.max(boundedStart, Math.min(editor.length, Number(end)))
+        const handled = editorView.runEditTransaction("set-date", function() {
+            editor.remove(boundedStart, boundedEnd)
+            editor.insert(boundedStart, replacement)
+            editor.cursorPosition = boundedStart + replacement.length
+            editor.commitText(false)
+            editor.rememberPlainText()
+            return true
+        })
+        if (handled)
+            Qt.callLater(root.refresh)
+        return Boolean(handled)
+    }
+
+    function openDatePicker(start, end, dateText) {
+        if (!editor || !editor.renderedMarkdown || editor.codeDocument)
+            return false
+        datePicker.openFor(editor, start, end, dateText)
+        return true
+    }
+
+    function armDateShortcut(event) {
+        pendingDateShortcutStart = -1
+        if (!editor || !editor.renderedMarkdown || editor.codeDocument
+                || editor.selectionStart !== editor.selectionEnd || event.text !== "/")
+            return false
+
+        const position = editor.cursorPosition
+        if (position <= 0 || editor.getText(position - 1, position) !== "/")
+            return false
+        const before = position > 1 ? editor.getText(position - 2, position - 1) : ""
+        // Keep this deliberately stricter than date boundary detection. It
+        // avoids URL schemes (https://) and path-like text without guessing.
+        if (before.length > 0 && !/\s/.test(before))
+            return false
+
+        const link = editorView.editorBackend.linkInfo(editor.textDocument, position - 1, position)
+        if (link && link.valid && link.href)
+            return false
+        if (editorView.editorBackend.inlineFormatEnabled(editor.textDocument, position, "code"))
+            return false
+
+        pendingDateShortcutStart = position - 1
+        dateShortcutTimer.restart()
+        return true
+    }
+
+    Timer {
+        id: dateShortcutTimer
+        interval: 0
+        repeat: false
+        onTriggered: {
+            const start = root.pendingDateShortcutStart
+            root.pendingDateShortcutStart = -1
+            if (start < 0 || !root.editor || root.editor.selectionStart !== root.editor.selectionEnd)
+                return
+            if (root.editor.getText(start, start + 2) !== "//")
+                return
+            root.openDatePicker(start, start + 2, "")
+        }
+    }
+
+    Timer {
+        interval: 60000
+        repeat: true
+        running: root.elements.length > 0
+        onTriggered: {
+            const current = root.startOfDay(new Date())
+            if (current.getTime() !== root.today.getTime())
+                root.today = current
+        }
+    }
+
+    Repeater {
+        model: root.elements
+        delegate: Item {
+            required property var modelData
+            anchors.fill: parent
+
+            DateChip {
+                anchors.fill: parent
+                visible: parent.modelData && parent.modelData.type === "date"
+                editor: root.editor
+                element: parent.modelData
+                urgencyState: root.dateState(parent.modelData.dateText)
+                layoutRevision: root.layoutRevision
+                onActivated: root.openDatePicker(element.start, element.end, element.dateText)
+            }
+        }
+    }
+
+    DatePickerPopup {
+        id: datePicker
+        editorView: root.editorView
+        onDateChosen: function(value) {
+            root.replaceRangeWithDate(datePicker.selectionStart, datePicker.selectionEnd, value)
+        }
+    }
+}

--- a/libanykeep/qml/editor/components/InlineElementLayer.qml
+++ b/libanykeep/qml/editor/components/InlineElementLayer.qml
@@ -291,10 +291,10 @@ Item {
     function replaceRangeWithDate(start, end, value, addSeparator) {
         const date = startOfDay(value)
         const replacement = isoDate(date)
-        const boundedStart = Math.max(0, Math.min(editor.length, Number(start)))
-        const boundedEnd = Math.max(boundedStart, Math.min(editor.length, Number(end)))
-        const characterAfter = boundedEnd < editor.length
-                ? editor.getText(boundedEnd, boundedEnd + 1) : ""
+        const plain = editor.currentPlainText()
+        const boundedStart = Math.max(0, Math.min(plain.length, Number(start)))
+        const boundedEnd = Math.max(boundedStart, Math.min(plain.length, Number(end)))
+        const characterAfter = boundedEnd < plain.length ? plain.charAt(boundedEnd) : ""
         let suffix = ""
         let existingSeparatorAdvance = 0
         if (Boolean(addSeparator)) {

--- a/libanykeep/qml/editor/components/InlineElementLayer.qml
+++ b/libanykeep/qml/editor/components/InlineElementLayer.qml
@@ -14,6 +14,8 @@ Item {
     property int pendingDateShortcutStart: -1
     property bool datePickerAddsSeparator: false
     property bool inlineCaretOn: true
+    property bool normalizingCursor: false
+    property int lastCursorPosition: -1
 
     function startOfDay(value) {
         return new Date(value.getFullYear(), value.getMonth(), value.getDate())
@@ -78,6 +80,8 @@ Item {
                 || !editorView || !editorView.editorBackend) {
             elements = []
             ++layoutRevision
+            if (editor)
+                lastCursorPosition = Number(editor.cursorPosition)
             return
         }
 
@@ -113,6 +117,9 @@ Item {
         }
         elements = discovered
         ++layoutRevision
+        if (lastCursorPosition < 0)
+            lastCursorPosition = Number(editor.cursorPosition)
+        Qt.callLater(root.normalizeCursorAndSelection)
     }
 
     function invalidateGeometry() {
@@ -138,35 +145,103 @@ Item {
         return null
     }
 
-    function dateForNavigation(position, direction) {
+    function dateContainingPosition(position) {
+        const value = Number(position)
         for (const element of elements) {
-            if (!element || element.type !== "date")
-                continue
-            if (direction > 0 && position >= element.start && position < element.end)
-                return element
-            if (direction < 0 && position > element.start && position <= element.end)
+            if (element && element.type === "date"
+                    && value > element.start && value < element.end)
                 return element
         }
         return null
     }
 
-    function canMoveAcrossDate(direction) {
-        return editor && editor.activeFocus
-                && editor.selectionStart === editor.selectionEnd
-                && dateForNavigation(editor.cursorPosition, Number(direction)) !== null
+    function normalizedSelectionBoundary(position, startBoundary) {
+        const element = dateContainingPosition(position)
+        if (!element)
+            return Number(position)
+        return Boolean(startBoundary) ? element.start : element.end
     }
 
-    function moveAcrossDate(direction) {
-        if (!editor || editor.selectionStart !== editor.selectionEnd)
+    function normalizeCursorAndSelection() {
+        if (!editor || normalizingCursor)
             return false
-        const step = Number(direction)
-        const element = dateForNavigation(editor.cursorPosition, step)
-        if (!element)
+
+        const current = Number(editor.cursorPosition)
+        const selectionStart = Number(editor.selectionStart)
+        const selectionEnd = Number(editor.selectionEnd)
+        const previous = lastCursorPosition
+
+        if (selectionStart !== selectionEnd) {
+            const activeElement = dateContainingPosition(current)
+            if (activeElement) {
+                const activeAtStart = current === selectionStart
+                const anchor = activeAtStart ? selectionEnd : selectionStart
+                let target
+
+                if (anchor <= activeElement.start) {
+                    // Expanding from the left selects the entire widget at
+                    // once. Contracting back into a previously selected date
+                    // drops the entire widget at once instead of exposing its
+                    // individual source characters.
+                    target = previous >= activeElement.end && current < previous
+                            ? activeElement.start : activeElement.end
+                } else if (anchor >= activeElement.end) {
+                    target = previous >= 0 && previous <= activeElement.start
+                            && current > previous
+                            ? activeElement.end : activeElement.start
+                } else {
+                    target = current - activeElement.start
+                            < activeElement.end - current
+                            ? activeElement.start : activeElement.end
+                }
+
+                normalizingCursor = true
+                editor.select(anchor, target)
+                lastCursorPosition = Number(editor.cursorPosition)
+                normalizingCursor = false
+                return true
+            }
+
+            // Programmatic selections and cross-editor mouse selection can
+            // occasionally move the non-active boundary without first moving
+            // the cursor. Never leave either endpoint inside a widget.
+            const normalizedStart = normalizedSelectionBoundary(selectionStart, true)
+            const normalizedEnd = normalizedSelectionBoundary(selectionEnd, false)
+            if (normalizedStart !== selectionStart || normalizedEnd !== selectionEnd) {
+                const activeAtStart = current === selectionStart
+                normalizingCursor = true
+                if (activeAtStart)
+                    editor.select(normalizedEnd, normalizedStart)
+                else
+                    editor.select(normalizedStart, normalizedEnd)
+                lastCursorPosition = Number(editor.cursorPosition)
+                normalizingCursor = false
+                return true
+            }
+
+            lastCursorPosition = current
             return false
-        editor.cursorPosition = step > 0 ? element.end : element.start
-        editorView.activeEditor = editor
-        inlineCaretOn = true
-        inlineCaretTimer.restart()
+        }
+
+        const element = dateContainingPosition(current)
+        if (!element) {
+            lastCursorPosition = current
+            return false
+        }
+
+        let target
+        if (previous >= 0 && previous <= element.start)
+            target = element.end
+        else if (previous >= element.end)
+            target = element.start
+        else
+            target = current - element.start < element.end - current
+                    ? element.start : element.end
+
+        normalizingCursor = true
+        editor.cursorPosition = target
+        lastCursorPosition = target
+        normalizingCursor = false
         return true
     }
 
@@ -225,9 +300,8 @@ Item {
         if (Boolean(addSeparator)) {
             if (characterAfter === " " || characterAfter === "\t")
                 existingSeparatorAdvance = 1
-            else if (characterAfter.length === 0)
-                suffix = " "
-            else if (characterAfter !== "\n" && characterAfter !== "\r"
+            else if (characterAfter.length > 0
+                     && characterAfter !== "\n" && characterAfter !== "\r"
                      && ".,;:!?)]}".indexOf(characterAfter) < 0)
                 suffix = " "
         }
@@ -280,18 +354,6 @@ Item {
         return true
     }
 
-    Shortcut {
-        sequence: "Left"
-        enabled: root.canMoveAcrossDate(-1)
-        onActivated: root.moveAcrossDate(-1)
-    }
-
-    Shortcut {
-        sequence: "Right"
-        enabled: root.canMoveAcrossDate(1)
-        onActivated: root.moveAcrossDate(1)
-    }
-
     Timer {
         id: dateShortcutTimer
         interval: 0
@@ -334,12 +396,18 @@ Item {
         target: root.editor
         ignoreUnknownSignals: true
         function onCursorPositionChanged() {
+            if (!root.normalizingCursor)
+                root.normalizeCursorAndSelection()
             root.inlineCaretOn = true
             if (inlineCaretTimer.running)
                 inlineCaretTimer.restart()
         }
         function onActiveFocusChanged() {
             root.inlineCaretOn = true
+            if (root.editor && root.editor.activeFocus) {
+                root.lastCursorPosition = Number(root.editor.cursorPosition)
+                Qt.callLater(root.normalizeCursorAndSelection)
+            }
         }
     }
 

--- a/libanykeep/qml/editor/components/NoteBlockTextArea.qml
+++ b/libanykeep/qml/editor/components/NoteBlockTextArea.qml
@@ -315,6 +315,10 @@ TextArea {
             cursorPosition = restoredCursor
         }
         rememberPlainText()
+        Qt.callLater(function() {
+            if (blockArea)
+                inlineElementLayer.refresh()
+        })
         return true
     }
 
@@ -436,13 +440,17 @@ TextArea {
     onSourceTextChanged: {
         synchronizeSourceText()
         Qt.callLater(function() {
-            if (blockArea)
+            if (blockArea) {
                 blockArea.registerTextDocument()
+                inlineElementLayer.refresh()
+            }
         })
     }
     onTextFormatChanged: Qt.callLater(function() {
-        if (blockArea)
+        if (blockArea) {
             blockArea.registerTextDocument()
+            inlineElementLayer.refresh()
+        }
     })
     onTitleDocumentChanged: registerTextDocument()
     onSyntaxLanguageChanged: registerTextDocument()
@@ -471,6 +479,9 @@ TextArea {
         }
     }
     onCursorPositionChanged: editorView.scheduleCursorVisibility(blockArea)
+    onWidthChanged: inlineElementLayer.invalidateGeometry()
+    onHeightChanged: inlineElementLayer.invalidateGeometry()
+    onFontChanged: inlineElementLayer.invalidateGeometry()
     Component.onCompleted: {
         synchronizeSourceText(true)
         editorView.registerEditor(blockArea)
@@ -479,6 +490,7 @@ TextArea {
                 && typeof editorView.platformBackend.setActiveSpellCheckDocument === "function")
             editorView.platformBackend.setActiveSpellCheckDocument(textDocument)
         rememberPlainText()
+        inlineElementLayer.refresh()
         spellRefresh.restart()
     }
     Component.onDestruction: editorView.unregisterEditor(blockArea)
@@ -530,6 +542,7 @@ TextArea {
     Keys.priority: Keys.BeforeItem
     Keys.onPressed: function(event) {
         armPendingInlineFormatting(event)
+        inlineElementLayer.armDateShortcut(event)
         if (event.key === Qt.Key_Control || event.key === Qt.Key_Meta) {
             primaryModifierDown = true
             editorMouseArea.refreshPlainLinkHover(event.modifiers)
@@ -547,6 +560,9 @@ TextArea {
         } else if (!blockArea.codeDocument && blockArea.handleLinkSpaceExit(event)) {
             event.accepted = true
         } else if (blockArea.handleDocumentSelectionTextReplacement(event)) {
+            event.accepted = true
+        } else if ((event.key === Qt.Key_Delete || event.key === Qt.Key_Backspace)
+                   && inlineElementLayer.deleteDateAtCursor(event.key === Qt.Key_Backspace)) {
             event.accepted = true
         } else if ((event.key === Qt.Key_Delete || event.key === Qt.Key_Backspace)
                 && editorView.deleteStructuredSelection(event.key === Qt.Key_Backspace)) {
@@ -697,6 +713,13 @@ TextArea {
             return null
         const info = editorView.editorBackend.linkInfo(textDocument, position, position + 1)
         return info && info.valid && info.href ? info : null
+    }
+
+    InlineElementLayer {
+        id: inlineElementLayer
+        anchors.fill: parent
+        editor: blockArea
+        editorView: blockArea.editorView
     }
 
     Timer {

--- a/src/mobile/CMakeLists.txt
+++ b/src/mobile/CMakeLists.txt
@@ -60,6 +60,9 @@ set(anykeep_mobile_editor_qml
 set(anykeep_mobile_editor_component_qml
     "${CMAKE_SOURCE_DIR}/libanykeep/qml/editor/components/CompactPopupSelector.qml"
     "${CMAKE_SOURCE_DIR}/libanykeep/qml/editor/components/HoverActionStrip.qml"
+    "${CMAKE_SOURCE_DIR}/libanykeep/qml/editor/components/DateChip.qml"
+    "${CMAKE_SOURCE_DIR}/libanykeep/qml/editor/components/DatePickerPopup.qml"
+    "${CMAKE_SOURCE_DIR}/libanykeep/qml/editor/components/InlineElementLayer.qml"
     "${CMAKE_SOURCE_DIR}/libanykeep/qml/editor/components/ListBlockEditor.qml"
     "${CMAKE_SOURCE_DIR}/libanykeep/qml/editor/components/NoteBlockTextArea.qml"
     "${CMAKE_SOURCE_DIR}/libanykeep/qml/editor/components/TagLineEditor.qml")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,9 @@ target_link_libraries(desktopnoteeditorhost_test PRIVATE Qt6::QuickWidgets)
 add_anykeep_test(editorqml_test editorqml_test.cpp)
 target_link_libraries(editorqml_test PRIVATE Qt6::QuickWidgets)
 
+add_anykeep_test(inlineelementsqml_test inlineelementsqml_test.cpp)
+target_link_libraries(inlineelementsqml_test PRIVATE Qt6::QuickWidgets)
+
 add_anykeep_test(
   notesmanagerqml_test
   notesmanagerqml_test.cpp
@@ -80,15 +83,16 @@ set_target_properties(notesmanagerqml_test PROPERTIES AUTORCC ON)
 add_anykeep_test(settingsqml_test settingsqml_test.cpp desktopqmltestsupport.h)
 target_link_libraries(settingsqml_test PRIVATE Qt6::QuickWidgets)
 
-add_custom_target(desktop_qml_tests DEPENDS desktopnoteeditorhost_test editorqml_test notesmanagerqml_test
-                                            settingsqml_test)
+add_custom_target(desktop_qml_tests DEPENDS desktopnoteeditorhost_test editorqml_test inlineelementsqml_test
+                                            notesmanagerqml_test settingsqml_test)
 
 # One stable entry point for structured-editor work.  The target builds the model/controller/QML layers together, while
 # the matching CTest label runs exactly the same focused set without maintaining a regular expression in contributor
 # instructions or automation.
-add_custom_target(editor_tests DEPENDS noteblockmodel_test noteeditor_test desktopnoteeditorhost_test editorqml_test)
+add_custom_target(editor_tests DEPENDS noteblockmodel_test noteeditor_test desktopnoteeditorhost_test editorqml_test
+                                       inlineelementsqml_test)
 set_tests_properties(noteblockmodel_test noteeditor_test PROPERTIES LABELS editor)
-set_tests_properties(desktopnoteeditorhost_test editorqml_test PROPERTIES LABELS "editor;qml")
+set_tests_properties(desktopnoteeditorhost_test editorqml_test inlineelementsqml_test PROPERTIES LABELS "editor;qml")
 set_tests_properties(notesmanagerqml_test PROPERTIES LABELS "notesmanager;qml")
 set_tests_properties(settingsqml_test PROPERTIES LABELS "settings;qml")
 

--- a/tests/draftmanagertransfer_test.cpp
+++ b/tests/draftmanagertransfer_test.cpp
@@ -155,6 +155,7 @@ private slots:
     void publishesDestinationBeforeDeletingSource();
     void preservesSourceWhenDestinationPublicationFails();
     void resumesPublishingDraftForEditing();
+    void excludesActiveEditingSessionFromCrashRecovery();
     void prepareForShutdownRequeuesPublishingDraft();
     void exposesPendingPublicationDrafts();
     void publishesFavoriteOnlyChangesForMultipleNotesAndAllowsRemoval();
@@ -308,6 +309,26 @@ void DraftManagerTransferTest::resumesPublishingDraftForEditing()
     QCOMPARE(data->records_.value(record.id).state, DraftRecord::Editing);
     QCOMPARE(drafts.recoverableDrafts().size(), 1);
     QCOMPARE(drafts.recoverableDrafts().constFirst().id, record.id);
+}
+
+void DraftManagerTransferTest::excludesActiveEditingSessionFromCrashRecovery()
+{
+    TransferStorage storage(QStringLiteral("delayed-storage"));
+    const auto      note
+        = storage.addStored(QStringLiteral("open-note"), QStringLiteral("Open note"), QStringLiteral("Body"));
+    DraftManager drafts(std::make_unique<MemoryDraftStore>());
+
+    const auto draftId = drafts.acquireEditingSession(note);
+    QVERIFY(!draftId.isNull());
+    const auto saved = drafts.saveEditing(draftId, note, note.title(), note.text(), note.format());
+    QVERIFY2(!saved, qPrintable(saved.message));
+
+    QVERIFY(drafts.recoverableDrafts().isEmpty());
+
+    QVERIFY(drafts.releaseEditingSession(draftId));
+    const auto recoverable = drafts.recoverableDrafts();
+    QCOMPARE(recoverable.size(), 1);
+    QCOMPARE(recoverable.constFirst().id, draftId);
 }
 
 void DraftManagerTransferTest::prepareForShutdownRequeuesPublishingDraft()

--- a/tests/inlineelementsqml_test.cpp
+++ b/tests/inlineelementsqml_test.cpp
@@ -160,6 +160,54 @@ private slots:
         QCOMPARE(state.toString(), QStringLiteral("future"));
     }
 
+    void cursorNavigationTreatsDateAsAtomic()
+    {
+        const QString dateText = QStringLiteral("2030-12-31");
+        Note note(new NoteData(nullptr));
+        note.setTitle(QStringLiteral("title"));
+        note.setText(QStringLiteral("before %1 after").arg(dateText), Note::Markdown);
+        DraftManager          drafts(std::make_unique<MemoryDraftStore>());
+        NoteEditor            editor(note, drafts);
+        DesktopNoteEditorHost host(&editor);
+        host.resize(520, 320);
+        host.show();
+
+        auto *root = qobject_cast<QQuickItem *>(host.quickWidget()->rootObject());
+        QVERIFY(root);
+        QQuickItem *body = nullptr;
+        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        QObject *layer = nullptr;
+        QTRY_VERIFY((layer = inlineLayer(body)));
+        refreshInlineLayer(layer);
+        QTRY_COMPARE(int(inlineElements(layer).size()), 1);
+
+        const int start = currentPlainText(body).indexOf(dateText);
+        QVERIFY(start >= 0);
+        const int end = start + dateText.size();
+        body->forceActiveFocus(Qt::MouseFocusReason);
+        QTRY_VERIFY(body->hasActiveFocus());
+
+        QVariant handled;
+        body->setProperty("cursorPosition", start);
+        QVERIFY(QMetaObject::invokeMethod(layer, "moveAcrossDate", Q_RETURN_ARG(QVariant, handled),
+                                          Q_ARG(QVariant, QVariant(1))));
+        QVERIFY(handled.toBool());
+        QCOMPARE(body->property("cursorPosition").toInt(), end);
+
+        handled = {};
+        QVERIFY(QMetaObject::invokeMethod(layer, "moveAcrossDate", Q_RETURN_ARG(QVariant, handled),
+                                          Q_ARG(QVariant, QVariant(-1))));
+        QVERIFY(handled.toBool());
+        QCOMPARE(body->property("cursorPosition").toInt(), start);
+
+        body->setProperty("cursorPosition", start + 4);
+        handled = {};
+        QVERIFY(QMetaObject::invokeMethod(layer, "moveAcrossDate", Q_RETURN_ARG(QVariant, handled),
+                                          Q_ARG(QVariant, QVariant(1))));
+        QVERIFY(handled.toBool());
+        QCOMPARE(body->property("cursorPosition").toInt(), end);
+    }
+
     void backspaceAndDeleteTreatDateAsAtomic()
     {
         const QString dateText = QStringLiteral("2030-12-31");

--- a/tests/inlineelementsqml_test.cpp
+++ b/tests/inlineelementsqml_test.cpp
@@ -312,7 +312,7 @@ private slots:
         QTRY_VERIFY(!editor.text().contains(dateText));
     }
 
-    void shortcutReplacementAtEndLeavesCaretAfterDate()
+    void shortcutReplacementAtEndKeepsSeparatorForTyping()
     {
         const QString dateText = QStringLiteral("2030-12-31");
         Note note(new NoteData(nullptr));
@@ -347,9 +347,10 @@ private slots:
                                           Q_ARG(QVariant, dateValue), Q_ARG(QVariant, QVariant(true))));
         QVERIFY(handled.toBool());
 
-        // A separator at EOL has no Markdown meaning and Qt normalizes it.
-        // Keep the source clean and leave the caret on the right widget edge.
-        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31"));
+        // Keep the continuation separator only in the live QTextDocument.
+        // The model already contains the date, so an otherwise meaningless
+        // trailing Markdown space is not persisted by itself.
+        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31 "));
         QCOMPARE(body->property("cursorPosition").toInt(), currentPlainText(body).size());
         QTRY_VERIFY(editor.text().contains(QStringLiteral("before 2030-12-31")));
         QVERIFY(!editor.text().contains(QStringLiteral("//")));
@@ -357,12 +358,11 @@ private slots:
         refreshInlineLayer(layer);
         QTRY_COMPARE(int(inlineElements(layer).size()), 1);
 
-        handled = {};
-        QVERIFY(QMetaObject::invokeMethod(layer, "deleteDateAtCursor", Q_RETURN_ARG(QVariant, handled),
-                                          Q_ARG(QVariant, QVariant(true))));
-        QVERIFY(handled.toBool());
-        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before "));
-        QTRY_VERIFY(!editor.text().contains(dateText));
+        QTest::keyClicks(host.quickWidget(), QStringLiteral("x"));
+        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31 x"));
+        QTRY_VERIFY(editor.text().contains(QStringLiteral("before 2030-12-31 x")));
+        refreshInlineLayer(layer);
+        QTRY_COMPARE(int(inlineElements(layer).size()), 1);
     }
 
     void shortcutReplacementSeparatesFollowingText()

--- a/tests/inlineelementsqml_test.cpp
+++ b/tests/inlineelementsqml_test.cpp
@@ -312,7 +312,7 @@ private slots:
         QTRY_VERIFY(!editor.text().contains(dateText));
     }
 
-    void shortcutReplacementAtEndKeepsSeparatorForTyping()
+    void shortcutReplacementSeparatesFirstTypedCharacter()
     {
         const QString dateText = QStringLiteral("2030-12-31");
         Note note(new NoteData(nullptr));
@@ -347,10 +347,8 @@ private slots:
                                           Q_ARG(QVariant, dateValue), Q_ARG(QVariant, QVariant(true))));
         QVERIFY(handled.toBool());
 
-        // Keep the continuation separator only in the live QTextDocument.
-        // The model already contains the date, so an otherwise meaningless
-        // trailing Markdown space is not persisted by itself.
-        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31 "));
+        // EOL stays clean: no transient trailing space is required.
+        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31"));
         QCOMPARE(body->property("cursorPosition").toInt(), currentPlainText(body).size());
         QTRY_VERIFY(editor.text().contains(QStringLiteral("before 2030-12-31")));
         QVERIFY(!editor.text().contains(QStringLiteral("//")));
@@ -358,9 +356,44 @@ private slots:
         refreshInlineLayer(layer);
         QTRY_COMPARE(int(inlineElements(layer).size()), 1);
 
+        // The first ordinary character is intercepted before TextArea inserts
+        // it. Separator + character are inserted atomically, so the date never
+        // turns into the invalid token "2030-12-31x".
         QTest::keyClicks(host.quickWidget(), QStringLiteral("x"));
         QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31 x"));
         QTRY_VERIFY(editor.text().contains(QStringLiteral("before 2030-12-31 x")));
+        refreshInlineLayer(layer);
+        QTRY_COMPARE(int(inlineElements(layer).size()), 1);
+    }
+
+    void punctuationAfterDateNeedsNoSeparator()
+    {
+        const QString dateText = QStringLiteral("2030-12-31");
+        Note note(new NoteData(nullptr));
+        note.setTitle(QStringLiteral("title"));
+        note.setText(QStringLiteral("before %1").arg(dateText), Note::Markdown);
+        DraftManager          drafts(std::make_unique<MemoryDraftStore>());
+        NoteEditor            editor(note, drafts);
+        DesktopNoteEditorHost host(&editor);
+        host.resize(520, 320);
+        host.show();
+
+        auto *root = qobject_cast<QQuickItem *>(host.quickWidget()->rootObject());
+        QVERIFY(root);
+        QQuickItem *body = nullptr;
+        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        QObject *layer = nullptr;
+        QTRY_VERIFY((layer = inlineLayer(body)));
+        refreshInlineLayer(layer);
+        QTRY_COMPARE(int(inlineElements(layer).size()), 1);
+
+        body->forceActiveFocus(Qt::MouseFocusReason);
+        QTRY_VERIFY(body->hasActiveFocus());
+        body->setProperty("cursorPosition", currentPlainText(body).size());
+
+        QTest::keyClicks(host.quickWidget(), QStringLiteral(","));
+        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31,"));
+        QTRY_VERIFY(editor.text().contains(QStringLiteral("before 2030-12-31,")));
         refreshInlineLayer(layer);
         QTRY_COMPARE(int(inlineElements(layer).size()), 1);
     }

--- a/tests/inlineelementsqml_test.cpp
+++ b/tests/inlineelementsqml_test.cpp
@@ -219,7 +219,7 @@ private slots:
     {
         Note note(new NoteData(nullptr));
         note.setTitle(QStringLiteral("title"));
-        note.setText(QStringLiteral("| Date |\n| --- |\n| 2030-12-31 |"), Note::Markdown);
+        note.setText(QStringLiteral("| Date | Other |\n| --- | --- |\n| 2030-12-31 | value |"), Note::Markdown);
         DraftManager          drafts(std::make_unique<MemoryDraftStore>());
         NoteEditor            editor(note, drafts);
         DesktopNoteEditorHost host(&editor);
@@ -232,10 +232,10 @@ private slots:
         QList<QQuickItem *> cells;
         QTRY_VERIFY(([&]() {
             cells = tableCellEditors(root, 1);
-            return cells.size() == 2;
+            return cells.size() == 4;
         })());
 
-        QObject *layer = inlineLayer(cells.constLast());
+        QObject *layer = inlineLayer(cells.at(2));
         QVERIFY(layer);
         refreshInlineLayer(layer);
         QTRY_COMPARE(int(inlineElements(layer).size()), 1);

--- a/tests/inlineelementsqml_test.cpp
+++ b/tests/inlineelementsqml_test.cpp
@@ -187,25 +187,74 @@ private slots:
         body->forceActiveFocus(Qt::MouseFocusReason);
         QTRY_VERIFY(body->hasActiveFocus());
 
-        QVariant handled;
         body->setProperty("cursorPosition", start);
-        QVERIFY(QMetaObject::invokeMethod(layer, "moveAcrossDate", Q_RETURN_ARG(QVariant, handled),
-                                          Q_ARG(QVariant, QVariant(1))));
-        QVERIFY(handled.toBool());
-        QCOMPARE(body->property("cursorPosition").toInt(), end);
+        QTest::keyClick(host.quickWidget(), Qt::Key_Right);
+        QTRY_COMPARE(body->property("cursorPosition").toInt(), end);
 
-        handled = {};
-        QVERIFY(QMetaObject::invokeMethod(layer, "moveAcrossDate", Q_RETURN_ARG(QVariant, handled),
-                                          Q_ARG(QVariant, QVariant(-1))));
-        QVERIFY(handled.toBool());
-        QCOMPARE(body->property("cursorPosition").toInt(), start);
+        QTest::keyClick(host.quickWidget(), Qt::Key_Left);
+        QTRY_COMPARE(body->property("cursorPosition").toInt(), start);
 
+        // Cursor placement from the left cannot leave the caret in the source
+        // characters hidden by the QML widget.
         body->setProperty("cursorPosition", start + 4);
-        handled = {};
-        QVERIFY(QMetaObject::invokeMethod(layer, "moveAcrossDate", Q_RETURN_ARG(QVariant, handled),
-                                          Q_ARG(QVariant, QVariant(1))));
-        QVERIFY(handled.toBool());
-        QCOMPARE(body->property("cursorPosition").toInt(), end);
+        QTRY_COMPARE(body->property("cursorPosition").toInt(), end);
+
+        // The same placement while approaching from the right resolves to the
+        // other widget boundary.
+        body->setProperty("cursorPosition", start + 6);
+        QTRY_COMPARE(body->property("cursorPosition").toInt(), start);
+    }
+
+    void selectionTreatsDateAsAtomic()
+    {
+        const QString dateText = QStringLiteral("2030-12-31");
+        Note note(new NoteData(nullptr));
+        note.setTitle(QStringLiteral("title"));
+        note.setText(QStringLiteral("before %1 after").arg(dateText), Note::Markdown);
+        DraftManager          drafts(std::make_unique<MemoryDraftStore>());
+        NoteEditor            editor(note, drafts);
+        DesktopNoteEditorHost host(&editor);
+        host.resize(520, 320);
+        host.show();
+
+        auto *root = qobject_cast<QQuickItem *>(host.quickWidget()->rootObject());
+        QVERIFY(root);
+        QQuickItem *body = nullptr;
+        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        QObject *layer = nullptr;
+        QTRY_VERIFY((layer = inlineLayer(body)));
+        refreshInlineLayer(layer);
+        QTRY_COMPARE(int(inlineElements(layer).size()), 1);
+
+        const int start = currentPlainText(body).indexOf(dateText);
+        QVERIFY(start >= 0);
+        const int end = start + dateText.size();
+        body->forceActiveFocus(Qt::MouseFocusReason);
+        QTRY_VERIFY(body->hasActiveFocus());
+
+        body->setProperty("cursorPosition", start);
+        QTest::keyClick(host.quickWidget(), Qt::Key_Right, Qt::ShiftModifier);
+        QTRY_COMPARE(body->property("selectionStart").toInt(), start);
+        QTRY_COMPARE(body->property("selectionEnd").toInt(), end);
+        QTRY_COMPARE(body->property("cursorPosition").toInt(), end);
+
+        // Contracting the selection back into the widget drops it as one
+        // atomic unit instead of selecting nine of its ten source characters.
+        QTest::keyClick(host.quickWidget(), Qt::Key_Left, Qt::ShiftModifier);
+        QTRY_COMPARE(body->property("selectionStart").toInt(), start);
+        QTRY_COMPARE(body->property("selectionEnd").toInt(), start);
+        QTRY_COMPARE(body->property("cursorPosition").toInt(), start);
+
+        body->setProperty("cursorPosition", end);
+        QTest::keyClick(host.quickWidget(), Qt::Key_Left, Qt::ShiftModifier);
+        QTRY_COMPARE(body->property("selectionStart").toInt(), start);
+        QTRY_COMPARE(body->property("selectionEnd").toInt(), end);
+        QTRY_COMPARE(body->property("cursorPosition").toInt(), start);
+
+        QTest::keyClick(host.quickWidget(), Qt::Key_Right, Qt::ShiftModifier);
+        QTRY_COMPARE(body->property("selectionStart").toInt(), end);
+        QTRY_COMPARE(body->property("selectionEnd").toInt(), end);
+        QTRY_COMPARE(body->property("cursorPosition").toInt(), end);
     }
 
     void backspaceAndDeleteTreatDateAsAtomic()
@@ -263,7 +312,7 @@ private slots:
         QTRY_VERIFY(!editor.text().contains(dateText));
     }
 
-    void shortcutReplacementAddsSeparatorAndMovesCaret()
+    void shortcutReplacementAtEndLeavesCaretAfterDate()
     {
         const QString dateText = QStringLiteral("2030-12-31");
         Note note(new NoteData(nullptr));
@@ -298,11 +347,9 @@ private slots:
                                           Q_ARG(QVariant, dateValue), Q_ARG(QVariant, QVariant(true))));
         QVERIFY(handled.toBool());
 
-        // Markdown serialization may normalize a trailing space, but the
-        // focused QTextDocument deliberately keeps it as an input separator.
-        // That leaves the caret one real character beyond the inline widget
-        // so the user can immediately continue typing ordinary text.
-        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31 "));
+        // A separator at EOL has no Markdown meaning and Qt normalizes it.
+        // Keep the source clean and leave the caret on the right widget edge.
+        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31"));
         QCOMPARE(body->property("cursorPosition").toInt(), currentPlainText(body).size());
         QTRY_VERIFY(editor.text().contains(QStringLiteral("before 2030-12-31")));
         QVERIFY(!editor.text().contains(QStringLiteral("//")));
@@ -316,6 +363,48 @@ private slots:
         QVERIFY(handled.toBool());
         QTRY_COMPARE(currentPlainText(body), QStringLiteral("before "));
         QTRY_VERIFY(!editor.text().contains(dateText));
+    }
+
+    void shortcutReplacementSeparatesFollowingText()
+    {
+        const QString dateText = QStringLiteral("2030-12-31");
+        Note note(new NoteData(nullptr));
+        note.setTitle(QStringLiteral("title"));
+        note.setText(QStringLiteral("before //after"), Note::Markdown);
+        DraftManager          drafts(std::make_unique<MemoryDraftStore>());
+        NoteEditor            editor(note, drafts);
+        DesktopNoteEditorHost host(&editor);
+        host.resize(520, 320);
+        host.show();
+
+        auto *root = qobject_cast<QQuickItem *>(host.quickWidget()->rootObject());
+        QVERIFY(root);
+        QQuickItem *body = nullptr;
+        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        QObject *layer = nullptr;
+        QTRY_VERIFY((layer = inlineLayer(body)));
+        body->forceActiveFocus(Qt::MouseFocusReason);
+        QTRY_VERIFY(body->hasActiveFocus());
+
+        const int shortcutStart = currentPlainText(body).indexOf(QStringLiteral("//"));
+        QVERIFY(shortcutStart >= 0);
+        QVariant dateValue;
+        QVERIFY(QMetaObject::invokeMethod(layer, "dateFromIso", Q_RETURN_ARG(QVariant, dateValue),
+                                          Q_ARG(QVariant, QVariant(dateText))));
+        QVERIFY(dateValue.isValid());
+
+        QVariant handled;
+        QVERIFY(QMetaObject::invokeMethod(layer, "replaceRangeWithDate", Q_RETURN_ARG(QVariant, handled),
+                                          Q_ARG(QVariant, QVariant(shortcutStart)),
+                                          Q_ARG(QVariant, QVariant(shortcutStart + 2)),
+                                          Q_ARG(QVariant, dateValue), Q_ARG(QVariant, QVariant(true))));
+        QVERIFY(handled.toBool());
+
+        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31 after"));
+        const int followingStart = currentPlainText(body).indexOf(QStringLiteral("after"));
+        QVERIFY(followingStart > 0);
+        QCOMPARE(body->property("cursorPosition").toInt(), followingStart);
+        QTRY_VERIFY(editor.text().contains(QStringLiteral("2030-12-31 after")));
     }
 
     void tableCellsUseTheSameInlineDateLayer()

--- a/tests/inlineelementsqml_test.cpp
+++ b/tests/inlineelementsqml_test.cpp
@@ -1,0 +1,248 @@
+#include <QDate>
+#include <QJSValue>
+#include <QQuickItem>
+#include <QQuickWidget>
+#include <QtTest>
+
+#include <algorithm>
+#include <memory>
+
+#include "desktopnoteeditorhost.h"
+#include "draftmanager.h"
+#include "noteblockmodel.h"
+#include "noteeditor.h"
+
+#include "editortestsupport.h"
+
+using namespace AnyKeep;
+using namespace AnyKeep::TestSupport;
+
+namespace {
+
+QList<QQuickItem *> textEditors(QQuickItem *root)
+{
+    QList<QQuickItem *> result;
+    if (!root)
+        return result;
+    if (root->objectName() == QLatin1String("noteBlockTextArea"))
+        result.append(root);
+    for (QQuickItem *child : root->childItems())
+        result.append(textEditors(child));
+    return result;
+}
+
+QQuickItem *textEditorForBlock(QQuickItem *root, int blockIndex)
+{
+    for (QQuickItem *editor : textEditors(root)) {
+        if (editor->property("blockIndex").toInt() == blockIndex && editor->property("tableCellIndex").toInt() < 0
+            && editor->property("listItemIndex").toInt() < 0) {
+            return editor;
+        }
+    }
+    return nullptr;
+}
+
+QList<QQuickItem *> tableCellEditors(QQuickItem *root, int blockIndex)
+{
+    QList<QQuickItem *> result;
+    for (QQuickItem *editor : textEditors(root)) {
+        if (editor->property("blockIndex").toInt() == blockIndex && editor->property("tableCellIndex").toInt() >= 0)
+            result.append(editor);
+    }
+    std::sort(result.begin(), result.end(), [](QQuickItem *left, QQuickItem *right) {
+        return left->property("tableCellIndex").toInt() < right->property("tableCellIndex").toInt();
+    });
+    return result;
+}
+
+QObject *inlineLayer(QQuickItem *editor)
+{
+    return editor ? editor->findChild<QObject *>(QStringLiteral("inlineElementLayer")) : nullptr;
+}
+
+QVariantList inlineElements(QObject *layer)
+{
+    if (!layer)
+        return {};
+    const QVariant value = layer->property("elements");
+    if (value.metaType() == QMetaType::fromType<QJSValue>()) {
+        const QJSValue array = value.value<QJSValue>();
+        QVariantList result;
+        const int length = array.property(QStringLiteral("length")).toInt();
+        result.reserve(length);
+        for (int index = 0; index < length; ++index)
+            result.append(array.property(index).toVariant());
+        return result;
+    }
+    return value.toList();
+}
+
+QString currentPlainText(QQuickItem *editor)
+{
+    QVariant value;
+    if (!editor || !QMetaObject::invokeMethod(editor, "currentPlainText", Q_RETURN_ARG(QVariant, value)))
+        return {};
+    return value.toString();
+}
+
+void refreshInlineLayer(QObject *layer)
+{
+    if (layer)
+        QMetaObject::invokeMethod(layer, "refresh");
+}
+
+} // namespace
+
+class InlineElementsQmlTest : public QObject {
+    Q_OBJECT
+
+private slots:
+    void recognizesOnlyStandaloneSemanticDates()
+    {
+        Note note(new NoteData(nullptr));
+        note.setTitle(QStringLiteral("title"));
+        note.setText(QStringLiteral("due 2030-12-31 invalid 2030-02-30 code `2030-01-01` "
+                                    "link [2030-03-04](https://example.com) "
+                                    "url https://example.com/2030-05-06"),
+                     Note::Markdown);
+        DraftManager          drafts(std::make_unique<MemoryDraftStore>());
+        NoteEditor            editor(note, drafts);
+        DesktopNoteEditorHost host(&editor);
+        host.resize(700, 360);
+        host.show();
+
+        auto *root = qobject_cast<QQuickItem *>(host.quickWidget()->rootObject());
+        QVERIFY(root);
+        QQuickItem *body = nullptr;
+        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        QObject *layer = nullptr;
+        QTRY_VERIFY((layer = inlineLayer(body)));
+        refreshInlineLayer(layer);
+
+        QTRY_COMPARE(int(inlineElements(layer).size()), 1);
+        const QVariantMap element = inlineElements(layer).constFirst().toMap();
+        QCOMPARE(element.value(QStringLiteral("type")).toString(), QStringLiteral("date"));
+        QCOMPARE(element.value(QStringLiteral("dateText")).toString(), QStringLiteral("2030-12-31"));
+    }
+
+    void dateUrgencyUsesLocalCalendarDays()
+    {
+        Note note(new NoteData(nullptr));
+        note.setTitle(QStringLiteral("title"));
+        note.setText(QStringLiteral("date 2030-12-31"), Note::Markdown);
+        DraftManager          drafts(std::make_unique<MemoryDraftStore>());
+        NoteEditor            editor(note, drafts);
+        DesktopNoteEditorHost host(&editor);
+        host.resize(520, 320);
+        host.show();
+
+        auto *root = qobject_cast<QQuickItem *>(host.quickWidget()->rootObject());
+        QVERIFY(root);
+        QQuickItem *body = nullptr;
+        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        QObject *layer = nullptr;
+        QTRY_VERIFY((layer = inlineLayer(body)));
+
+        const QDate today = QDate::currentDate();
+        const auto stateFor = [&](const QDate &date, QVariant *result) {
+            return QMetaObject::invokeMethod(layer, "dateState", Q_RETURN_ARG(QVariant, *result),
+                                             Q_ARG(QVariant, QVariant(date.toString(Qt::ISODate))));
+        };
+
+        QVariant state;
+        QVERIFY(stateFor(today.addDays(-1), &state));
+        QCOMPARE(state.toString(), QStringLiteral("overdue"));
+        QVERIFY(stateFor(today, &state));
+        QCOMPARE(state.toString(), QStringLiteral("soon"));
+        QVERIFY(stateFor(today.addDays(7), &state));
+        QCOMPARE(state.toString(), QStringLiteral("soon"));
+        QVERIFY(stateFor(today.addDays(8), &state));
+        QCOMPARE(state.toString(), QStringLiteral("future"));
+    }
+
+    void backspaceAndDeleteTreatDateAsAtomic()
+    {
+        const QString dateText = QStringLiteral("2030-12-31");
+        Note note(new NoteData(nullptr));
+        note.setTitle(QStringLiteral("title"));
+        note.setText(QStringLiteral("before %1 after").arg(dateText), Note::Markdown);
+        DraftManager          drafts(std::make_unique<MemoryDraftStore>());
+        NoteEditor            editor(note, drafts);
+        DesktopNoteEditorHost host(&editor);
+        host.resize(520, 320);
+        host.show();
+
+        auto *root = qobject_cast<QQuickItem *>(host.quickWidget()->rootObject());
+        QVERIFY(root);
+        QQuickItem *body = nullptr;
+        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        QObject *layer = nullptr;
+        QTRY_VERIFY((layer = inlineLayer(body)));
+        refreshInlineLayer(layer);
+        QTRY_COMPARE(int(inlineElements(layer).size()), 1);
+
+        int start = currentPlainText(body).indexOf(dateText);
+        QVERIFY(start >= 0);
+        body->forceActiveFocus(Qt::MouseFocusReason);
+        body->setProperty("cursorPosition", start + dateText.size());
+        QTRY_VERIFY(body->hasActiveFocus());
+
+        QVariant handled;
+        QVERIFY(QMetaObject::invokeMethod(layer, "deleteDateAtCursor", Q_RETURN_ARG(QVariant, handled),
+                                          Q_ARG(QVariant, QVariant(true))));
+        QVERIFY(handled.toBool());
+        QTRY_VERIFY(!editor.text().contains(dateText));
+
+        QVERIFY(editor.undo());
+        QTRY_VERIFY(editor.text().contains(dateText));
+
+        body = nullptr;
+        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        layer = nullptr;
+        QTRY_VERIFY((layer = inlineLayer(body)));
+        refreshInlineLayer(layer);
+        QTRY_COMPARE(int(inlineElements(layer).size()), 1);
+        start = currentPlainText(body).indexOf(dateText);
+        QVERIFY(start >= 0);
+        body->forceActiveFocus(Qt::MouseFocusReason);
+        body->setProperty("cursorPosition", start);
+        QTRY_VERIFY(body->hasActiveFocus());
+
+        handled = {};
+        QVERIFY(QMetaObject::invokeMethod(layer, "deleteDateAtCursor", Q_RETURN_ARG(QVariant, handled),
+                                          Q_ARG(QVariant, QVariant(false))));
+        QVERIFY(handled.toBool());
+        QTRY_VERIFY(!editor.text().contains(dateText));
+    }
+
+    void tableCellsUseTheSameInlineDateLayer()
+    {
+        Note note(new NoteData(nullptr));
+        note.setTitle(QStringLiteral("title"));
+        note.setText(QStringLiteral("| Date |\n| --- |\n| 2030-12-31 |"), Note::Markdown);
+        DraftManager          drafts(std::make_unique<MemoryDraftStore>());
+        NoteEditor            editor(note, drafts);
+        DesktopNoteEditorHost host(&editor);
+        host.resize(520, 360);
+        host.show();
+
+        auto *root = qobject_cast<QQuickItem *>(host.quickWidget()->rootObject());
+        QVERIFY(root);
+        QCOMPARE(editor.model()->blockTypeAt(1), int(NoteBlockModel::Table));
+        QList<QQuickItem *> cells;
+        QTRY_VERIFY(([&]() {
+            cells = tableCellEditors(root, 1);
+            return cells.size() == 2;
+        })());
+
+        QObject *layer = inlineLayer(cells.constLast());
+        QVERIFY(layer);
+        refreshInlineLayer(layer);
+        QTRY_COMPARE(int(inlineElements(layer).size()), 1);
+        QCOMPARE(inlineElements(layer).constFirst().toMap().value(QStringLiteral("dateText")).toString(),
+                 QStringLiteral("2030-12-31"));
+    }
+};
+
+QTEST_MAIN(InlineElementsQmlTest)
+#include "inlineelementsqml_test.moc"

--- a/tests/inlineelementsqml_test.cpp
+++ b/tests/inlineelementsqml_test.cpp
@@ -281,6 +281,8 @@ private slots:
         QTRY_VERIFY((body = textEditorForBlock(root, 1)));
         QObject *layer = nullptr;
         QTRY_VERIFY((layer = inlineLayer(body)));
+        body->forceActiveFocus(Qt::MouseFocusReason);
+        QTRY_VERIFY(body->hasActiveFocus());
 
         const int shortcutStart = currentPlainText(body).indexOf(QStringLiteral("//"));
         QVERIFY(shortcutStart >= 0);
@@ -295,26 +297,25 @@ private slots:
                                           Q_ARG(QVariant, QVariant(shortcutStart + 2)),
                                           Q_ARG(QVariant, dateValue), Q_ARG(QVariant, QVariant(true))));
         QVERIFY(handled.toBool());
-        QTRY_COMPARE(editor.text(), QStringLiteral("before 2030-12-31 "));
 
-        body = nullptr;
-        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        // Markdown serialization may normalize a trailing space, but the
+        // focused QTextDocument deliberately keeps it as an input separator.
+        // That leaves the caret one real character beyond the inline widget
+        // so the user can immediately continue typing ordinary text.
         QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31 "));
         QCOMPARE(body->property("cursorPosition").toInt(), currentPlainText(body).size());
+        QTRY_VERIFY(editor.text().contains(QStringLiteral("before 2030-12-31")));
+        QVERIFY(!editor.text().contains(QStringLiteral("//")));
 
-        layer = nullptr;
-        QTRY_VERIFY((layer = inlineLayer(body)));
         refreshInlineLayer(layer);
         QTRY_COMPARE(int(inlineElements(layer).size()), 1);
-        body->forceActiveFocus(Qt::MouseFocusReason);
-        body->setProperty("cursorPosition", currentPlainText(body).size());
-        QTRY_VERIFY(body->hasActiveFocus());
 
         handled = {};
         QVERIFY(QMetaObject::invokeMethod(layer, "deleteDateAtCursor", Q_RETURN_ARG(QVariant, handled),
                                           Q_ARG(QVariant, QVariant(true))));
         QVERIFY(handled.toBool());
-        QTRY_COMPARE(editor.text(), QStringLiteral("before "));
+        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before "));
+        QTRY_VERIFY(!editor.text().contains(dateText));
     }
 
     void tableCellsUseTheSameInlineDateLayer()

--- a/tests/inlineelementsqml_test.cpp
+++ b/tests/inlineelementsqml_test.cpp
@@ -215,6 +215,60 @@ private slots:
         QTRY_VERIFY(!editor.text().contains(dateText));
     }
 
+    void shortcutReplacementAddsSeparatorAndMovesCaret()
+    {
+        const QString dateText = QStringLiteral("2030-12-31");
+        Note note(new NoteData(nullptr));
+        note.setTitle(QStringLiteral("title"));
+        note.setText(QStringLiteral("before //"), Note::Markdown);
+        DraftManager          drafts(std::make_unique<MemoryDraftStore>());
+        NoteEditor            editor(note, drafts);
+        DesktopNoteEditorHost host(&editor);
+        host.resize(520, 320);
+        host.show();
+
+        auto *root = qobject_cast<QQuickItem *>(host.quickWidget()->rootObject());
+        QVERIFY(root);
+        QQuickItem *body = nullptr;
+        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        QObject *layer = nullptr;
+        QTRY_VERIFY((layer = inlineLayer(body)));
+
+        const int shortcutStart = currentPlainText(body).indexOf(QStringLiteral("//"));
+        QVERIFY(shortcutStart >= 0);
+        QVariant dateValue;
+        QVERIFY(QMetaObject::invokeMethod(layer, "dateFromIso", Q_RETURN_ARG(QVariant, dateValue),
+                                          Q_ARG(QVariant, QVariant(dateText))));
+        QVERIFY(dateValue.isValid());
+
+        QVariant handled;
+        QVERIFY(QMetaObject::invokeMethod(layer, "replaceRangeWithDate", Q_RETURN_ARG(QVariant, handled),
+                                          Q_ARG(QVariant, QVariant(shortcutStart)),
+                                          Q_ARG(QVariant, QVariant(shortcutStart + 2)),
+                                          Q_ARG(QVariant, dateValue), Q_ARG(QVariant, QVariant(true))));
+        QVERIFY(handled.toBool());
+        QTRY_COMPARE(editor.text(), QStringLiteral("before 2030-12-31 "));
+
+        body = nullptr;
+        QTRY_VERIFY((body = textEditorForBlock(root, 1)));
+        QTRY_COMPARE(currentPlainText(body), QStringLiteral("before 2030-12-31 "));
+        QCOMPARE(body->property("cursorPosition").toInt(), currentPlainText(body).size());
+
+        layer = nullptr;
+        QTRY_VERIFY((layer = inlineLayer(body)));
+        refreshInlineLayer(layer);
+        QTRY_COMPARE(int(inlineElements(layer).size()), 1);
+        body->forceActiveFocus(Qt::MouseFocusReason);
+        body->setProperty("cursorPosition", currentPlainText(body).size());
+        QTRY_VERIFY(body->hasActiveFocus());
+
+        handled = {};
+        QVERIFY(QMetaObject::invokeMethod(layer, "deleteDateAtCursor", Q_RETURN_ARG(QVariant, handled),
+                                          Q_ARG(QVariant, QVariant(true))));
+        QVERIFY(handled.toBool());
+        QTRY_COMPARE(editor.text(), QStringLiteral("before "));
+    }
+
     void tableCellsUseTheSameInlineDateLayer()
     {
         Note note(new NoteData(nullptr));


### PR DESCRIPTION
Adds reusable inline QML elements to the Markdown editor, with dates as the first element type.

- render valid standalone `YYYY-MM-DD` values as interactive QML date chips while keeping plain ISO text in Markdown/QTextDocument
- color overdue dates red, today through +7 days yellow, and later dates green
- open a MonthGrid date picker from a chip or the Confluence-style `//` shortcut
- treat date chips atomically for Backspace/Delete and date replacement
- exclude invalid dates, inline code, links and URL/path-like date text
- share the same inline layer across text, lists/task lists and table cells
- add focused QML regression tests and mobile QML resource wiring